### PR TITLE
Avoid max() in parsing loop to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-*Currently none*
+- Performance improvements in the parser
 
 # v1.6.2
 

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -53,8 +53,9 @@ class TagScriptParser:
         # this is an extremely hot loop so there are additional local references to
         # instance attributes in order to squeeze a bit more performance from the
         # parser
+        char = ""
         while i < input_len:
-            previous_char = input_str[max(i - 1, 0)]
+            previous_char = char
             char = input_str[i]
             block: BlockParseState | None = self._state
             current_state = block.state if block is not None else None


### PR DESCRIPTION
This small change to avoid the call to `max()` and the additional string slice to set `previous_char` yields some decent performance increases:

(all explicit numbers referring to 1,000 interpretation runs total, relative changes are obviously the same for single runs)
- ~17% faster runtime for the benchmark script used (20.1s -> 16.6s) (22ms -> 17ms in single runs)
- ~29% fewer function calls (54M -> 38M) (54k -> 38k in single runs)
- ~22% lower `tottime` spent in `parse()` (8.8s -> 6.8s) (9ms -> 7ms in single runs)
- 15.6M calls to (and 1.2s of runtime in) `max()` replaced with a basically "free" variable definition (15.6k calls and ~1ms `tottime` in single runs)

Obviously, this is just one benchmark, but the script used (see `bench.py` below) is very long (10,000+ chars) and has loads of blocks in it (12 different kinds provided in the interpreter during benchmarking). If a big script like this can be sped up, I'm sure the gains will also translate to smaller scripts.

## Profile on current `main` (235cf9855ce4896dec5a48a488b87caa6a8ce709)
```console
> python bench.py
         54077013 function calls (52456013 primitive calls) in 20.092 seconds

   Ordered by: cumulative time
   List reduced from 98 to 20 due to restriction <20>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.006    0.006   20.176   20.176	ya_tagscript\.local\bench.py:198(run_workload)
     1000		0.012    0.000   20.171    0.020	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:40(process)
685000/2000		0.492    0.000   20.157    0.010	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:72(_interpret)
   156000		8.833    0.000   13.891    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.372    0.000   11.947    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:118(_process_node)
291000/105000	0.729    0.000   11.709    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:108(_process_context)
670000/179000	0.223    0.000   10.809    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.091    0.000   10.214    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.085    0.000    5.462    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.091    0.000    3.237    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
  2340000		2.085    0.000    2.925    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
 14764000		1.473    0.000    1.473    0.000	{method 'append' of 'list' objects}
4000/3000		0.003    0.000    1.457    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
   876000		0.672    0.000    1.334    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:72(transition_state)
 15633000		1.209    0.000    1.209    0.000	{built-in method builtins.max}
10000/1000		0.020    0.000    1.186    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.250    0.000    0.664    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:52(finalize)
     5000		0.014    0.000    0.531    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
     5000		0.003    0.000    0.483    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   447000		0.204    0.000    0.396    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:342(_flush_text_buffer)
```

## Changes from this PR
```console
         38444013 function calls (36823013 primitive calls) in 16.683 seconds

   Ordered by: cumulative time
   List reduced from 97 to 20 due to restriction <20>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.006    0.006   16.765   16.765	ya_tagscript\.local\bench.py:198(run_workload)
     1000		0.011    0.000   16.760    0.017	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:40(process)
685000/2000		0.487    0.000   16.747    0.008	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:72(_interpret)
   156000		6.891    0.000   10.592    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.365    0.000   10.562    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:118(_process_node)
291000/105000	0.716    0.000   10.330    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:108(_process_context)
670000/179000	0.216    0.000    9.440    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.089    0.000    8.906    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.084    0.000    4.965    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.089    0.000    2.966    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
  2340000		2.057    0.000    2.883    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
 14764000		1.418    0.000    1.418    0.000	{method 'append' of 'list' objects}
   876000		0.645    0.000    1.271    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:72(transition_state)
4000/3000		0.003    0.000    1.168    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.019    0.000    0.947    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.244    0.000    0.647    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:52(finalize)
     5000		0.014    0.000    0.492    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
     5000		0.003    0.000    0.445    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   447000		0.201    0.000    0.385    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
108000/106000	0.092    0.000    0.379    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
```

---

### `bench.py`
```python
import cProfile
import io
import pstats

from ya_tagscript import TagScriptInterpreter, adapters, blocks

test_script = """\
{require(Member,Server Supporter,Honorary Member,Support,Staff,Admin):}

{delete}

{//:Change the prefix and tag name to match your server's settings.}
{=(prefix):!}
{=(tagname):rule}

{//:
If you would like the tag to always display a link to your rules channel in the description when you are listing rules
Insert the channel id of your rules channel below. Leave completely blank and it will not display.}
{=(ruleschannelid):}

{//:Add, change or remove the embed title here}
{embed(title):}

{//:
Put custom titles in the titleN variables (if you want them).
Put keywords for each rule in the keywordN variables. Not required but useful.

The logic behind keyword detection has changed, LONG keywords are better. If you have "spamming" as the keyword, and do "!rule spam", it will detect it. 

You can provide multiple keywords for each rule IF you do NOT put spaces in between them. Use commas if you feel the need to separate them.

Put rules in the ruleN variables.
Titles must be less than 256 characters, and rules must be less than 1024 characters.
Some symbols in rule text might cause issues, limit formatting to Discord markdown friendly characters. 
DO NOT USE " or | in rule text.
Leave custom titles blank to have the titles just be "Rule #".
Leave corresponding title, keyword, and rule variables blank if the rule # does not exist, but do NOT erase the blank variables}

{//:
Make sure to append the overridden indices to this variable name wherever you define a realIndex/indexOverride pair. For example, on the 999,999th realIndex defined, put this after the realIndex definition:
{=(overriddenIndices):{overriddenIndices} {realIndex999999}}

Once you have all your indices adjust this way, don't forget to add the overrides to adjustedWs below
}
{=(overriddenIndices):}


{=(title01):}
{=(keyword01):readrules}
{=(rule01):**You have to follow both the global <#1195824391385272390> and channel-specific rules.** Ignorance of the rules is not an excuse; we expect you to have read them.}

{=(title02):}
{=(keyword02):nosupport}
{=(rule02):**You must not ask for support in any non-support channels.** Support channels includes <#1196111629482463422> and the forks channels. Make sure to also read <#1199996606771114024> and <#1195831024517660793> before seeking support.}

{=(title03):}
{=(keyword03):englishonly,nonenglish,language}
{=(rule03):**You must use the English language.** Some exceptions may be granted to non-conversational use, as well as specific support cases.}

{=(title04):}
{=(keyword04):commonsense}
{=(rule04):**Use common sense, don’t behave poorly.** No spam, harassment/mistreatment, unnecessary DMs/pings, ignoring Staff direction, deceptive/obfuscated links, slurs/pejoratives, or similar disruptive behavior.}

{=(title05):}
{=(keyword05):discordguidelines}
{=(rule05):**Follow the [community guidelines](https://discord.com/guidelines) set by Discord.** We didn't make these rules but we will enforce them, we don't make exceptions for anyone.}

{=(title06):}
{=(keyword06):wordfilter,circumvention}
{=(rule06):**You must not circumvent the word filter.** The filter is in place for a reason.}

{=(title07):}
{=(keyword07):spoilers}
{=(rule07):**Spoilable content needs to be marked with context.** Not everyone's definition is the same, you can read ours by using the `!spoilers` tag.}

{=(title08):}
{=(keyword08):advertising,advertisement,ads,serverinvites}
{=(rule08):**Do not advertise unprompted.** This includes posting server invites, advertisements, etc without permission from a staff member. This also includes DMing fellow members.}

{=(title09):}
{=(keyword09):impersonation}
{=(rule09):**No impersonation.** Do not pretend to be someone else, especially of members with roles.}

{=(title10):}
{=(keyword10):recommendations,sourcerecommendations,recs,repo,repos,reporecs,apk,apks}
{=(rule10):**No sources, third-party repos, or APKs: Do not share or name them.**
Do not share, link, recommend, or name any sources, third-party repositories, or APKs (including hints, initials, screenshots, or obfuscated links). They’re unaffiliated, unsupported, and their security isn’t guaranteed. Applies everywhere: channels, threads, and DMs (including Staff).}

{=(title11):}
{=(keyword11):politics }
{=(rule11):**No politics.** “There is a time and place for everything, but not here.” - Professor Oak.}

{//:Index overrides to compensate for non-sequential rule numbers.
realIndex = the actual index of this rule if there were no gaps.
overriddenIndex = the actually valid rule number as chosen by you.
overriddenIndices = collects all realIndex entries for later remapping. Remember to always append the new realIndex entry to this variable like below.
}
{=(realIndex1):12}
{=(indexOverride1):34}
{=(overriddenIndices):{realIndex1} {overriddenIndices}}
{=(title34):}
{=(keyword34):hentai,lewd}
{=(rule34):Lewd baka}

{//:Index overrides to compensate for non-sequential rule numbers.
realIndex = the actual index of this rule if there were no gaps.
overriddenIndex = the actually valid rule number as chosen by you.
overriddenIndices = collects all realIndex entries for later remapping. Remember to always append the new realIndex entry to this variable like below.
}
{=(realIndex2):13}
{=(indexOverride2):53}
{=(overriddenIndices):{realIndex2} {overriddenIndices}}
{=(title53):}
{=(keyword53):fumo}
{=(rule53):no fumo}

{//:Index overrides to compensate for non-sequential rule numbers.
realIndex = the actual index of this rule if there were no gaps.
overriddenIndex = the actually valid rule number as chosen by you.
overriddenIndices = collects all realIndex entries for later remapping. Remember to always append the new realIndex entry to this variable like below.
}
{=(realIndex3):14}
{=(indexOverride3):69}
{=(overriddenIndices):{realIndex3} {overriddenIndices}}
{=(title69):}
{=(keyword69):abuse}
{=(rule69):**Admin abuse** is actually allowed.}

{//:Title overrides, don't touch except to translate "Rule" into a different language}
{=(word4rule):Rule}

{//:Don't change anything below this comment}

{=(t01):{if(!={title01}):{title01}|{word4rule} 1}}
{=(t02):{if(!={title02}):{title02}|{word4rule} 2}}
{=(t03):{if(!={title03}):{title03}|{word4rule} 3}}
{=(t04):{if(!={title04}):{title04}|{word4rule} 4}}
{=(t05):{if(!={title05}):{title05}|{word4rule} 5}}
{=(t06):{if(!={title06}):{title06}|{word4rule} 6}}
{=(t07):{if(!={title07}):{title07}|{word4rule} 7}}
{=(t08):{if(!={title08}):{title08}|{word4rule} 8}}
{=(t09):{if(!={title09}):{title09}|{word4rule} 9}}
{=(t10):{if(!={title10}):{title10}|{word4rule} 10}}
{=(t11):{if(!={title11}):{title11}|{word4rule} 11}}
{=(t34):{if(!={title34}):{title34}|{word4rule} 34}}
{=(t53):{if(!={title53}):{title53}|{word4rule} 53}}
{=(t69):{if(!={title69}):{title69}|{word4rule} 69}}

{//:builds the list of rule numbers for rules that are populated}
{=(rules):{if(!={rule01(1)}):01}{if(!={rule02(1)}): 02}{if(!={rule03(1)}): 03}{if(!={rule04(1)}): 04}{if(!={rule05(1)}): 05}{if(!={rule06(1)}): 06}{if(!={rule07(1)}): 07}{if(!={rule08(1)}): 08}{if(!={rule09(1)}): 09}{if(!={rule10(1)}): 10}{if(!={rule11(1)}): 11}{if(!={rule34(1)}): 34}{if(!={rule53(1)}): 53}{if(!={rule69(1)}): 69}}

{//:Takes out the first channel mention present in args assuming it is present due to the desire for the rules to be sent to that channel}
{=(channelRemoved):{if({in(<#):{args}}==true):{replace({args({index(<#):{replace(<#,. <# .):{args}}})},):{args}}|{args}}}
{=(channelRemoved):{if(!={channelRemoved(1)}):{lower:{join( ):{channelRemoved}}}|00}}

{=(keywords):{if(!={keyword01(1):,}):{keyword01}}{if(!={keyword02(1):,}): {keyword02}}{if(!={keyword03(1):,}): {keyword03}}{if(!={keyword04(1):,}): {keyword04}}{if(!={keyword05(1):,}): {keyword05}}{if(!={keyword06(1):,}): {keyword06}}{if(!={keyword07(1):,}): {keyword07}}{if(!={keyword08(1):,}): {keyword08}}{if(!={keyword09(1):,}): {keyword09}}{if(!={keyword10(1):,}): {keyword10}}{if(!={keyword11(1):,}): {keyword11}}{if(!={keyword34(1):,}):{keyword34}}{if(!={keyword53(1):,}): {keyword53}}{if(!={keyword69(1):,}): {keyword69}}}

{//:Checks if the arg present is a keyword, and if it is, changes it to a rule number}
{=(ws):{if(!={channelRemoved(1)}):{if({in({channelRemoved(1)}):{keywords}}==true):{index({channelRemoved(1)}):{replace({channelRemoved(1)},. {channelRemoved(1)} .):{keywords}}}|{channelRemoved(1)}}|{channelRemoved(1)}}}

{//:Confusing, but: If the INPUT (paddedWs) is a number we're overriding, we do NOT want to redirect to that rule
(!rule 12 shouldn't output the content of Rule 34)
Index Overriding is ONLY for fixing the awkward handling of keywords.
}
{=(adjustedWs):{if({contains({channelRemoved}):{overriddenIndices}}):{ws}|{if({ws}=={realIndex1}):{indexOverride1}|{if({ws}=={realIndex2}):{indexOverride2}|{if({ws}=={realIndex3}):{indexOverride3}|{ws}}}}}}

{//:adds leading zeros to single digit numbers: adds ~ before and after the {ws} variable, joins with ~, replaces ~#~ with ~0#~, replaces ~ with spaces, then joins to remove leading/trailing spaces}
{=(paddedWs):{join():{replace(~, ):{replace(~1~,~01~):{replace(~2~,~02~):{replace(~3~,~03~):{replace(~4~,~04~):{replace(~5~,~05~):{replace(~6~,~06~):{replace(~7~,~07~):{replace(~8~,~08~):{replace(~9~,~09~):{join(~):~{adjustedWs}~}}}}}}}}}}}}}

{//:If the sanitized number does not match a number for a rule that exists, the tag displays the help window}
{=(num):{if({contains({paddedWs(1)}):{rules}}==true):{paddedWs(1)}|00}}

{if({and({num}!=00|{user(id)}!={target(id)}):true|false}==true):{target(mention)}}

{=(t00):Rules Command Instructions}
{=(rule00):Follow `{prefix}{tagname}` with the number or corresponding keyword of the rule you wish to output.

**__{server}'s Keywords:__**
- `{join(`
- `):{keywords}`}}

{embed(description):{if(!={ruleschannelid}):<#{ruleschannelid}>|}}

{embed(color):#2B2D31}
{embed(field):{t{num}}|{rule{num}}|false}
{embed(footer):Ruled by {user(nick)}|{user(avatar)}}
"""


def run_workload():
    interp = TagScriptInterpreter(
        blocks=[
            blocks.RequireBlock(),
            blocks.DeleteBlock(),
            blocks.CommentBlock(),
            blocks.AssignmentBlock(),
            blocks.EmbedBlock(),
            blocks.PythonBlock(),
            blocks.ReplaceBlock(),
            blocks.CaseBlock(),
            blocks.JoinBlock(),
            blocks.IfBlock(),
            blocks.AllBlock(),
            blocks.StrictVariableGetterBlock(),
        ]
    )
    seed_variables = {"args": adapters.StringAdapter("1")}
    for _ in range(1000):
        interp.process(test_script, seed_variables=seed_variables)


profiler = cProfile.Profile()
profiler.enable()
run_workload()
profiler.disable()

stream = io.StringIO()
stats = pstats.Stats(profiler, stream=stream)
stats.sort_stats("cumulative")
stats.print_stats(20)
print(stream.getvalue())
```