### PR TITLE
Speed up block lookup with dict of accepted names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Performance improvements in the parser
+- Performance improvements in the interpreter
 
 # v1.6.2
 

--- a/src/ya_tagscript/interpreter/interpreter.py
+++ b/src/ya_tagscript/interpreter/interpreter.py
@@ -26,7 +26,14 @@ _logger = logging.getLogger(__name__)
 
 class TagScriptInterpreter(InterpreterABC):
 
-    __slots__ = ("blocks", "_parser", "work_limit", "total_work")
+    __slots__ = (
+        "blocks",
+        "_parser",
+        "work_limit",
+        "total_work",
+        "_named_blocks",
+        "_unnamed_blocks",
+    )
 
     def __init__(
         self,
@@ -36,6 +43,20 @@ class TagScriptInterpreter(InterpreterABC):
         self.blocks: Sequence[BlockABC] = blocks
         self.work_limit: int | None = None
         self.total_work: int = 0
+        # fast lookup dict for blocks with non-None _accepted_names
+        self._named_blocks: dict[str, BlockABC] = {}
+        # fallback list for blocks with _accepted_names = None
+        self._unnamed_blocks: list[BlockABC] = []
+
+        # register blocks in the appropriate group
+        for block in blocks:
+            # noinspection PyProtectedMember
+            names = block._accepted_names  # pyright: ignore [reportPrivateUsage]
+            if names is not None:
+                for name in names:
+                    self._named_blocks[name.lower()] = block
+            else:
+                self._unnamed_blocks.append(block)
 
     def process(
         self,
@@ -106,7 +127,17 @@ class TagScriptInterpreter(InterpreterABC):
         return "".join(output)
 
     def _process_context(self, ctx: Context) -> str | None:
-        for b in self.blocks:
+        declaration = ctx.node.declaration
+        if declaration is not None:
+            named_block = self._named_blocks.get(declaration.lower())
+            if named_block is not None and named_block.will_accept(ctx):
+                processed = named_block.process(ctx)
+                if processed is not None:
+                    result = str(processed)
+                    ctx.node.output = result
+                    return result
+
+        for b in self._unnamed_blocks:
             if b.will_accept(ctx):
                 processed = b.process(ctx)
                 if processed is not None:

--- a/src/ya_tagscript/interpreter/interpreter.py
+++ b/src/ya_tagscript/interpreter/interpreter.py
@@ -45,7 +45,7 @@ class TagScriptInterpreter(InterpreterABC):
         self.total_work: int = 0
         # fast lookup dict for blocks with non-None _accepted_names
         self._named_blocks: dict[str, BlockABC] = {}
-        # fallback list for blocks with _accepted_names = None
+        # fallback list for blocks where _accepted_names is None
         self._unnamed_blocks: list[BlockABC] = []
 
         # register blocks in the appropriate group


### PR DESCRIPTION
Avoids O(n) block lookup on every call to `_process_context`.

This, on top of the optimizations in #24, delivers an additional performance improvement in the same benchmarking script.

- ~13% runtime reduction (16.9s -> 14.7s)
- ~21% function call reduction (38.4M -> 30.3M)
- ~50% `tottime` reduction in `_process_context()`, which previously iterated over every single block for every call
- ~92% reduction in calls to `will_accept()` (2.3M -> 176k) (changes avoid many unnecessary calls to it by looking up block names first and then checking for acceptance instead of testing every block for acceptance)
- ~91% `tottime` reduction in `will_accept()` (2.9s -> 0.28s)

## Current `v1` (00ee2af1e39dc9db937d97b39974b2edccc3eef9)
```console
> python .local\bench.py
         38444013 function calls (36823013 primitive calls) in 16.962 seconds

   Ordered by: cumulative time
   List reduced from 97 to 20 due to restriction <20>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.006    0.006   17.044   17.044	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.013    0.000   17.038    0.017	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:40(process)
685000/2000		0.499    0.000   17.024    0.009	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:72(_interpret)
437000/211000	0.368    0.000   10.751    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:118(_process_node)
   156000		6.979    0.000   10.747    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
291000/105000	0.731    0.000   10.516    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:108(_process_context)
670000/179000	0.224    0.000    9.603    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.092    0.000    9.059    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.086    0.000    5.054    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.092    0.000    3.021    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
  2340000		2.097    0.000    2.929    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
 14764000		1.448    0.000    1.448    0.000	{method 'append' of 'list' objects}
   876000		0.661    0.000    1.294    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:72(transition_state)
4000/3000		0.003    0.000    1.189    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.020    0.000    0.965    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.248    0.000    0.659    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:52(finalize)
     5000		0.015    0.000    0.506    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
     5000		0.004    0.000    0.455    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   447000		0.202    0.000    0.389    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
108000/106000	0.093    0.000    0.388    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
```

## Changes from this PR
```console
> python .local\bench.py
         30370048 function calls (28749048 primitive calls) in 14.784 seconds

   Ordered by: cumulative time
   List reduced from 98 to 20 due to restriction <20>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.007    0.007   14.867   14.867	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.014    0.000   14.860    0.015	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000		0.505    0.000   14.845    0.007	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		7.423    0.000   11.422    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.383    0.000    8.128    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.367    0.000    7.887    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.224    0.000    7.324    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.093    0.000    6.997    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.089    0.000    3.578    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.094    0.000    2.092    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
 14764001		1.557    0.000    1.557    0.000	{method 'append' of 'list' objects}
   876000		0.695    0.000    1.353    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:72(transition_state)
4000/3000		0.004    0.000    1.115    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.020    0.000    0.919    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.260    0.000    0.703    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:52(finalize)
   447000		0.211    0.000    0.411    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
     5000		0.017    0.000    0.370    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
108000/106000	0.092    0.000    0.356    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
     5000		0.004    0.000    0.314    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   176000		0.213    0.000    0.288    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
```