### PR TITLE
Optimize BlockParseState.transition_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-*Currently none*
+- Parser state optimizations
 
 # v1.6.3
 

--- a/src/ya_tagscript/interpreter/parse_state.py
+++ b/src/ya_tagscript/interpreter/parse_state.py
@@ -20,19 +20,6 @@ class ParseState(Enum):
     IN_PAYLOAD = auto()  # After the colon
 
 
-VALID_TRANSITIONS: dict[int, frozenset[ParseState]] = {
-    ParseState.EXPECTING_DECLARATION.value: frozenset({ParseState.IN_DECLARATION}),
-    ParseState.IN_DECLARATION.value: frozenset(
-        {ParseState.IN_PARAMETER, ParseState.IN_PAYLOAD},
-    ),
-    ParseState.IN_PARAMETER.value: frozenset({ParseState.POST_PARAMETER}),
-    ParseState.POST_PARAMETER.value: frozenset(
-        {ParseState.IN_PAYLOAD},
-    ),  # Or pop (not a state)
-    ParseState.IN_PAYLOAD.value: frozenset(),  # Only pop gets out of payload
-}
-
-
 @dataclass(slots=True)
 class BlockParseState:
     """
@@ -92,6 +79,28 @@ class BlockParseState:
             - EXPECTING_DECLARATION can transition to the base None state if the tokens
                 are "{}"
         """
-        if not next_state in VALID_TRANSITIONS.get(self.state.value, frozenset()):
+        if (
+            self.state == ParseState.EXPECTING_DECLARATION
+            and next_state == ParseState.IN_DECLARATION
+        ):
+            self.state = next_state
+
+        elif self.state == ParseState.IN_DECLARATION and (
+            next_state == ParseState.IN_PARAMETER or next_state == ParseState.IN_PAYLOAD
+        ):
+            self.state = next_state
+
+        elif (
+            self.state == ParseState.IN_PARAMETER
+            and next_state == ParseState.POST_PARAMETER
+        ):
+            self.state = next_state
+
+        elif (
+            self.state == ParseState.POST_PARAMETER
+            and next_state == ParseState.IN_PAYLOAD
+        ):
+            self.state = next_state
+
+        else:
             raise ValueError(f"Invalid state transition: {self.state} -> {next_state}")
-        self.state = next_state


### PR DESCRIPTION
Replaces the heavy dict-frozenset lookups with a dead simple if/elif construct.

The `bench.py` script is unchanged from its use in #25 and #24.

Some more optimizations of the hot parsing loop to squeeze some performance out of this.
- ~14% runtime reduction (14.3s -> 12.3s)
- ~14% function call reduction (30.3M -> 25.9M)
- ~71% `tottime` reduction for `transition_state()` (0.674s -> 0.194s)
- ~85% `cumtime` reduction for `transition_state()` (1.325s -> 0.194s)
- got rid of all 876,000 `enum.__get__` calls

## Current `v1` (4bed82ef0dae001a60ea59ec3ec180157f736c11)
```console
> python .local\bench.py
         30370048 function calls (28749048 primitive calls) in 14.347 seconds

   Ordered by: cumulative time
   List reduced from 98 to 20 due to restriction <20>

   ncalls        tottime  percall  cumtime  percall    filename:lineno(function)
        1        0.007    0.007   14.429   14.429    ya_tagscript\.local\bench.py:190(run_workload)
     1000        0.015    0.000   14.422    0.014    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000      0.491    0.000   14.406    0.007    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000        7.193    0.000   11.069    0.000    ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000    0.372    0.000    7.900    0.000    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000    0.356    0.000    7.664    0.000    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000    0.219    0.000    7.116    0.000    ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000        0.091    0.000    6.798    0.000    ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000      0.087    0.000    3.482    0.000    ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000      0.091    0.000    2.045    0.000    ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
 14764001        1.494    0.000    1.494    0.000    {method 'append' of 'list' objects}
   876000        0.674    0.000    1.325    0.000    ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:72(transition_state)
4000/3000        0.003    0.000    1.082    0.000    ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000       0.020    0.000    0.892    0.001    ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000        0.252    0.000    0.679    0.000    ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:52(finalize)
   447000        0.205    0.000    0.398    0.000    ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
     5000        0.016    0.000    0.361    0.000    ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
108000/106000    0.091    0.000    0.351    0.000    ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
     5000        0.004    0.000    0.306    0.000    ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   876000        0.211    0.000    0.281    0.000    C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\enum.py:187(__get__)
```

## Changes from this PR
(note: this is an extended profile showing the top 30 results instead of the top 20 to still capture the `transition_state` calls)
```console
> python .local\bench.py
         25990048 function calls (24369048 primitive calls) in 12.371 seconds

   Ordered by: cumulative time
   List reduced from 94 to 30 due to restriction <30>

   ncalls        tottime  percall  cumtime  percall    filename:lineno(function)
        1        0.005    0.005   12.448   12.448    ya_tagscript\.local\bench.py:190(run_workload)
     1000        0.011    0.000   12.443    0.012    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000      0.465    0.000   12.431    0.006    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000        6.758    0.000    9.314    0.000    ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000    0.351    0.000    6.762    0.000    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000    0.338    0.000    6.537    0.000    ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000    0.206    0.000    6.035    0.000    ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000        0.085    0.000    5.780    0.000    ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000      0.081    0.000    2.962    0.000    ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000      0.085    0.000    1.693    0.000    ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
 14764001        1.405    0.000    1.405    0.000    {method 'append' of 'list' objects}
4000/3000        0.003    0.000    0.956    0.000    ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000       0.018    0.000    0.785    0.001    ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000        0.231    0.000    0.616    0.000    ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   447000        0.189    0.000    0.362    0.000    ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
108000/106000    0.087    0.000    0.328    0.000    ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
     5000        0.013    0.000    0.303    0.000    ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
     5000        0.003    0.000    0.258    0.000    ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   176000        0.185    0.000    0.252    0.000    ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
   291000        0.194    0.000    0.234    0.000    ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
   876000        0.194    0.000    0.194    0.000    ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000        0.117    0.000    0.177    0.000    C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
   816000        0.175    0.000    0.175    0.000    {method 'join' of 'str' objects}
    39000        0.148    0.000    0.164    0.000    ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
115000/113000    0.061    0.000    0.160    0.000    ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:50(will_accept)
     4000        0.007    0.000    0.149    0.000    ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:63(process)
   108000        0.050    0.000    0.142    0.000    ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
1316000/1301000  0.117    0.000    0.134    0.000    {built-in method builtins.len}
    55000        0.089    0.000    0.124    0.000    ya_tagscript\src\ya_tagscript\util\conditionals.py:47(_find_zero_depth_operator)
     1000        0.003    0.000    0.124    0.000    ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
```