### PR TITLE
Use strings for accumulation instead of lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Parser state optimizations
+- Parsing and interpretation performance improvements
 
 # v1.6.3
 

--- a/src/ya_tagscript/interpreter/interpreter.py
+++ b/src/ya_tagscript/interpreter/interpreter.py
@@ -105,15 +105,15 @@ class TagScriptInterpreter(InterpreterABC):
             # in other words, this is plaintext to us
             return subject
         ast = self._parser.parse(subject)
-        output: list[str] = []
+        output: str = ""
         node_processing_fn = self._process_node
         for node in ast:
             try:
                 node_output = node_processing_fn(node, response, original)
-                output.append(node_output)
+                output += node_output
             except StopError as e:
                 _logger.debug("StopError raised on %r", node, exc_info=e)
-                output = [e.message]
+                output = e.message
                 break
 
             if node.type != NodeType.TEXT:
@@ -124,7 +124,7 @@ class TagScriptInterpreter(InterpreterABC):
                     node_output,
                 )
 
-        return "".join(output)
+        return output
 
     def _process_context(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration

--- a/src/ya_tagscript/interpreter/parse_state.py
+++ b/src/ya_tagscript/interpreter/parse_state.py
@@ -30,10 +30,10 @@ class BlockParseState:
     state: ParseState
     block_depth: int = 0
     paren_depth: int = 0
-    declaration: list[str] | None = None
-    parameter: list[str] | None = None
+    declaration: str | None = None
+    parameter: str | None = None
     has_parameter_section: bool = False  # True if 1-depth () exist, even if empty
-    payload: list[str] | None = None
+    payload: str | None = None
     has_payload_section: bool = False  # True if 1-depth : exists, even if empty
 
     def finalize(self) -> NodeABC:
@@ -41,16 +41,16 @@ class BlockParseState:
         if self.declaration is None:
             raise ValueError("Cannot finalize BLOCK Node without a declaration.")
 
-        parameter = "".join(self.parameter) if self.parameter is not None else None
+        parameter = self.parameter if self.parameter is not None else None
         if self.has_parameter_section and parameter is None:
             parameter = ""
 
-        payload = "".join(self.payload) if self.payload is not None else None
+        payload = self.payload if self.payload is not None else None
         if self.has_payload_section and payload is None:
             payload = ""
 
         node = Node.block(
-            declaration="".join(self.declaration),
+            declaration=self.declaration,
             parameter=parameter,
             payload=payload,
         )

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -38,13 +38,13 @@ class TagScriptParser:
     def __init__(self) -> None:
         self._nodes: list[NodeABC] = []
         self._state: BlockParseState | None = None
-        self._text_buffer: list[str] = []
+        self._text_buffer: str = ""
 
     def parse(self, input_str: str) -> list[NodeABC]:
         """Converts a string into a list of Nodes and handling nested blocks as text"""
         self._nodes = []
         self._state = None
-        self._text_buffer = []
+        self._text_buffer = ""
         i = 0
         input_len = len(input_str)
         special_chars = _SPECIAL_TOKENS
@@ -66,7 +66,7 @@ class TagScriptParser:
                 while i < input_len and input_str[i] not in special_chars:
                     i += 1
                 text = input_str[start:i]
-                self._text_buffer.append(text)
+                self._text_buffer += text
                 continue
 
             try:
@@ -75,7 +75,7 @@ class TagScriptParser:
                     if block is None or current_state is None:
                         if previous_char == BACKSLASH:
                             # escaped, don't start block
-                            self._text_buffer.append(char)
+                            self._text_buffer += char
                             i += 1
                             continue
                         self._flush_text_buffer()
@@ -91,52 +91,52 @@ class TagScriptParser:
 
                     if current_state == ParseState.EXPECTING_DECLARATION:
                         block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = [char]
+                        block.declaration = char
                     elif current_state == ParseState.IN_DECLARATION:
                         if block.declaration is None:
-                            block.declaration = [char]
+                            block.declaration = char
                         else:
-                            block.declaration.append(char)
+                            block.declaration += char
                     elif current_state == ParseState.IN_PARAMETER:
                         if block.parameter is None:
-                            block.parameter = [char]
+                            block.parameter = char
                         else:
-                            block.parameter.append(char)
+                            block.parameter += char
                     elif current_state == ParseState.IN_PAYLOAD:
                         if block.payload is None:
-                            block.payload = [char]
+                            block.payload = char
                         else:
-                            block.payload.append(char)
+                            block.payload += char
                     elif current_state == ParseState.POST_PARAMETER:
                         # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer.append(_reconstruct_partial_block(block))
-                        self._text_buffer.append(char)
+                        self._text_buffer += _reconstruct_partial_block(block)
+                        self._text_buffer += char
                         self._state = None
                     # endregion Opening brace handling
 
                 elif char == BRACE_CLOSE:
                     # region Closing brace handling
                     if block is None or current_state is None:
-                        self._text_buffer.append(char)
+                        self._text_buffer += char
                         i += 1
                         continue
                     elif block.block_depth == 1:
                         if previous_char == BACKSLASH:
                             if current_state == ParseState.IN_DECLARATION:
                                 if block.declaration is None:
-                                    block.declaration = [char]
+                                    block.declaration = char
                                 else:
-                                    block.declaration.append(char)
+                                    block.declaration += char
                             elif current_state == ParseState.IN_PARAMETER:
                                 if block.parameter is None:
-                                    block.parameter = [char]
+                                    block.parameter = char
                                 else:
-                                    block.parameter.append(char)
+                                    block.parameter += char
                             elif current_state == ParseState.IN_PAYLOAD:
                                 if block.payload is None:
-                                    block.payload = [char]
+                                    block.payload = char
                                 else:
-                                    block.payload.append(char)
+                                    block.payload += char
                             i += 1
                             continue
 
@@ -144,7 +144,7 @@ class TagScriptParser:
                             if current_state == ParseState.EXPECTING_DECLARATION:
                                 # {} found, illegal BLOCK node, treat as TEXT
                                 text = BRACE_OPEN + char
-                                self._text_buffer.append(text)
+                                self._text_buffer += text
                             else:
                                 self._nodes.append(block.finalize())
                             self._state = None
@@ -156,96 +156,96 @@ class TagScriptParser:
 
                     if current_state == ParseState.EXPECTING_DECLARATION:
                         block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = [char]
+                        block.declaration = char
                     elif current_state == ParseState.IN_DECLARATION:
                         if block.declaration is None:
-                            block.declaration = [char]
+                            block.declaration = char
                         else:
-                            block.declaration.append(char)
+                            block.declaration += char
                     elif current_state == ParseState.IN_PARAMETER:
                         if block.parameter is None:
-                            block.parameter = [char]
+                            block.parameter = char
                         else:
-                            block.parameter.append(char)
+                            block.parameter += char
                     elif current_state == ParseState.IN_PAYLOAD:
                         if block.payload is None:
-                            block.payload = [char]
+                            block.payload = char
                         else:
-                            block.payload.append(char)
+                            block.payload += char
                     elif current_state == ParseState.POST_PARAMETER:
                         # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer.append(_reconstruct_partial_block(block))
-                        self._text_buffer.append(char)
+                        self._text_buffer += _reconstruct_partial_block(block)
+                        self._text_buffer += char
                         self._state = None
                     # endregion Closing brace handling
 
                 elif char == PAREN_OPEN:
                     # region Opening paren handling
                     if block is None or current_state is None:
-                        self._text_buffer.append(char)
+                        self._text_buffer += char
                         i += 1
                         continue
 
                     block.paren_depth += 1
                     if current_state == ParseState.EXPECTING_DECLARATION:
                         block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = [char]
+                        block.declaration = char
                     elif current_state == ParseState.IN_DECLARATION:
                         if block.block_depth == 1:
                             block.has_parameter_section = True
                             block.transition_state(ParseState.IN_PARAMETER)
                         elif block.declaration is None:
-                            block.declaration = [char]
+                            block.declaration = char
                         else:
-                            block.declaration.append(char)
+                            block.declaration += char
                     elif current_state == ParseState.IN_PARAMETER:
                         if block.parameter is None:
-                            block.parameter = [char]
+                            block.parameter = char
                         else:
-                            block.parameter.append(char)
+                            block.parameter += char
                     elif current_state == ParseState.IN_PAYLOAD:
                         if block.payload is None:
-                            block.payload = [char]
+                            block.payload = char
                         else:
-                            block.payload.append(char)
+                            block.payload += char
                     elif current_state == ParseState.POST_PARAMETER:
                         # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer.append(_reconstruct_partial_block(block))
-                        self._text_buffer.append(char)
+                        self._text_buffer += _reconstruct_partial_block(block)
+                        self._text_buffer += char
                         self._state = None
                     # endregion Opening paren handling
 
                 elif char == PAREN_CLOSE:
                     # region Closing paren handling
                     if block is None or current_state is None:
-                        self._text_buffer.append(char)
+                        self._text_buffer += char
                         i += 1
                         continue
 
                     if current_state == ParseState.EXPECTING_DECLARATION:
                         block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = [char]
+                        block.declaration = char
                     elif current_state == ParseState.IN_DECLARATION:
                         if block.declaration is None:
-                            block.declaration = [char]
+                            block.declaration = char
                         else:
-                            block.declaration.append(char)
+                            block.declaration += char
                     elif current_state == ParseState.IN_PARAMETER:
                         if block.paren_depth == 1:
                             block.transition_state(ParseState.POST_PARAMETER)
                         elif block.parameter is None:
-                            block.parameter = [char]
+                            block.parameter = char
                         else:
-                            block.parameter.append(char)
+                            block.parameter += char
                     elif current_state == ParseState.IN_PAYLOAD:
                         if block.payload is None:
-                            block.payload = [char]
+                            block.payload = char
                         else:
-                            block.payload.append(char)
+                            block.payload += char
                     elif current_state == ParseState.POST_PARAMETER:
                         # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer.append(_reconstruct_partial_block(block))
-                        self._text_buffer.append(char)
+                        self._text_buffer += _reconstruct_partial_block(block)
+                        self._text_buffer += char
                         self._state = None
 
                     if block.paren_depth != 0:
@@ -255,13 +255,13 @@ class TagScriptParser:
                 elif char == COLON:
                     # region Colon handling
                     if block is None or current_state is None:
-                        self._text_buffer.append(char)
+                        self._text_buffer += char
                         i += 1
                         continue
 
                     if current_state == ParseState.EXPECTING_DECLARATION:
                         block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = [char]
+                        block.declaration = char
                     elif (
                         current_state
                         in (ParseState.IN_DECLARATION, ParseState.POST_PARAMETER)
@@ -272,21 +272,21 @@ class TagScriptParser:
                         block.transition_state(ParseState.IN_PAYLOAD)
                     elif current_state == ParseState.IN_DECLARATION:
                         if block.declaration is None:
-                            block.declaration = [char]
+                            block.declaration = char
                         else:
-                            block.declaration.append(char)
+                            block.declaration += char
                     elif current_state == ParseState.IN_PARAMETER:
                         if block.parameter is None:
-                            block.parameter = [char]
+                            block.parameter = char
                         else:
-                            block.parameter.append(char)
+                            block.parameter += char
                     elif current_state == ParseState.IN_PAYLOAD:
                         if block.payload is None:
-                            block.payload = [char]
+                            block.payload = char
                         else:
-                            block.payload.append(char)
+                            block.payload += char
                     else:
-                        self._text_buffer.append(char)
+                        self._text_buffer += char
                     # endregion Colon handling
 
                 else:
@@ -294,38 +294,38 @@ class TagScriptParser:
                     if block is None or current_state is None:
                         # unlikely if not impossible to hit but better safe than sorry
                         # (non-special chars are fast-tracked for None block above)
-                        self._text_buffer.append(char)
+                        self._text_buffer += char
                         i += 1
                         continue
 
                     if current_state == ParseState.EXPECTING_DECLARATION:
                         block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = [char]
+                        block.declaration = char
                     elif current_state == ParseState.IN_DECLARATION:
                         if block.declaration is None:
-                            block.declaration = [char]
+                            block.declaration = char
                         else:
-                            block.declaration.append(char)
+                            block.declaration += char
                     elif current_state == ParseState.IN_PARAMETER:
                         if block.parameter is None:
-                            block.parameter = [char]
+                            block.parameter = char
                         else:
-                            block.parameter.append(char)
+                            block.parameter += char
                     elif current_state == ParseState.IN_PAYLOAD:
                         if block.payload is None:
-                            block.payload = [char]
+                            block.payload = char
                         else:
-                            block.payload.append(char)
+                            block.payload += char
                     elif current_state == ParseState.POST_PARAMETER:
                         # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer.append(_reconstruct_partial_block(block))
-                        self._text_buffer.append(char)
+                        self._text_buffer += _reconstruct_partial_block(block)
+                        self._text_buffer += char
                         self._state = None
                     # endregion Any other char handling (including BACKSLASH)
 
             except ValueError as e:
                 _log.warning("Invalid state transition encountered: %r", e)
-                self._text_buffer.append(char)
+                self._text_buffer += char
 
             i += 1
         # endregion end of processing loop
@@ -334,7 +334,7 @@ class TagScriptParser:
         self._flush_text_buffer()
         if (block := self._state) is not None:
             raw_partial_block = _reconstruct_partial_block(block)
-            self._text_buffer.append(raw_partial_block)
+            self._text_buffer += raw_partial_block
             self._flush_text_buffer()
             self._state = None
 
@@ -348,19 +348,21 @@ class TagScriptParser:
             else:
                 text = "".join(self._text_buffer)
             self._nodes.append(Node.text(text_value=text))
-            self._text_buffer = []
+            self._text_buffer = ""
 
 
 def _reconstruct_partial_block(block: BlockParseState) -> str:
     """Reconstructs a partial block as text for error recovery."""
-    parts: list[str] = [BRACE_OPEN, "".join(block.declaration or [])]
+    out = BRACE_OPEN
+    if block.declaration is not None:
+        out += block.declaration
     if block.has_parameter_section:
-        parts.append(PAREN_OPEN)
+        out += PAREN_OPEN
         if block.parameter is not None:
-            parts.append("".join(block.parameter))
-        parts.append(PAREN_CLOSE)
+            out += block.parameter
+        out += PAREN_CLOSE
     if block.has_payload_section:
-        parts.append(COLON)
+        out += COLON
         if block.payload is not None:
-            parts.append("".join(block.payload))
-    return "".join(parts)
+            out += block.payload
+    return out


### PR DESCRIPTION
Another performance optimization for lists of strings that were just joined at the end anyway.

The `bench.py` script is unchanged from its use in #26, #25, #24.

Who would have thought that lists and list appending are more expensive than strings and string appending?

- ~20% runtime reduction (12.3s -> 9.8s)
- ~58% function call reduction (25.9M -> 10.9M)
- ~13% `tottime` reduction for `parse()` (6.758s -> 5.910s)
- ~97% reduction in calls to `list.append()` (14.7M -> 520k)
- ~95% `tottime` reduction in `list.append()` (1.405s -> 0.065s)
- ~39% `cumtime` reduction in `finalize()` (0.616s -> 0.373s)

not seen in the top 40 results below anymore, but found with an expanded profile (no restriction):
- ~93% reduction in calls to `str.join()` (816k -> 56k)
- ~87% `tottime` reduction in `str.join()` (0.175s -> 0.022s)

## Current `v1` (961d251fb244eb2d98022359f52f6e371ae5aebb)

```console
> python .local\bench.py
         25990048 function calls (24369048 primitive calls) in 12.371 seconds

   Ordered by: cumulative time
   List reduced from 94 to 30 due to restriction <30>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005   12.448   12.448	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.011    0.000   12.443    0.012	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000		0.465    0.000   12.431    0.006	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		6.758    0.000    9.314    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.351    0.000    6.762    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.338    0.000    6.537    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.206    0.000    6.035    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.085    0.000    5.780    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.081    0.000    2.962    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.085    0.000    1.693    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
 14764001		1.405    0.000    1.405    0.000	{method 'append' of 'list' objects}
4000/3000		0.003    0.000    0.956    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.018    0.000    0.785    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.231    0.000    0.616    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   447000		0.189    0.000    0.362    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
108000/106000	0.087    0.000    0.328    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
     5000		0.013    0.000    0.303    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
     5000		0.003    0.000    0.258    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   176000		0.185    0.000    0.252    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
   291000		0.194    0.000    0.234    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
   876000		0.194    0.000    0.194    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000		0.117    0.000    0.177    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
   816000		0.175    0.000    0.175    0.000	{method 'join' of 'str' objects}
    39000		0.148    0.000    0.164    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
115000/113000	0.061    0.000    0.160    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:50(will_accept)
     4000		0.007    0.000    0.149    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:63(process)
   108000		0.050    0.000    0.142    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
1316000/1301000	0.117    0.000    0.134    0.000	{built-in method builtins.len}
    55000		0.089    0.000    0.124    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:47(_find_zero_depth_operator)
     1000		0.003    0.000    0.124    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
```

## Changes from this PR
(note: this is an extended profile showing the top 40 results instead of the top 30 from #26 to still capture the `list.append` calls)
```console
> python .local\bench.py
         10986048 function calls (9365048 primitive calls) in 9.850 seconds

   Ordered by: cumulative time
   List reduced from 94 to 40 due to restriction <40>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005    9.927    9.927	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.010    0.000    9.922    0.010	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000		0.383    0.000    9.911    0.005	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		5.910    0.000    6.962    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.348    0.000    5.743    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.336    0.000    5.519    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.201    0.000    5.015    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.086    0.000    4.809    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.080    0.000    2.598    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.084    0.000    1.499    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
4000/3000		0.003    0.000    0.723    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.018    0.000    0.593    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   447000		0.196    0.000    0.391    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
   291000		0.138    0.000    0.373    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
108000/106000	0.087    0.000    0.326    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
     5000		0.013    0.000    0.273    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
   176000		0.188    0.000    0.259    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
   291000		0.194    0.000    0.236    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
     5000		0.003    0.000    0.230    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   876000		0.193    0.000    0.193    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000		0.117    0.000    0.175    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
    39000		0.150    0.000    0.167    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
115000/113000	0.061    0.000    0.157    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:50(will_accept)
   108000		0.051    0.000    0.143    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
1316000/1301000	0.113    0.000    0.130    0.000	{built-in method builtins.len}
     4000		0.007    0.000    0.129    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:63(process)
    55000		0.089    0.000    0.123    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:47(_find_zero_depth_operator)
     1000		0.003    0.000    0.112    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
   146000		0.092    0.000    0.111    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:69(text)
   291000		0.064    0.000    0.089    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:225(_check_workload)
   108000		0.045    0.000    0.080    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:64(_handle_ctx)
     1000		0.003    0.000    0.070    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\all_block.py:67(process)
   520001		0.065    0.000    0.065    0.000	{method 'append' of 'list' objects}
   405000		0.064    0.000    0.064    0.000	{method 'get' of 'dict' objects}
   488022		0.063    0.000    0.063    0.000	{method 'lower' of 'str' objects}
   437000		0.060    0.000    0.060    0.000	<string>:2(__init__)
     1000		0.000    0.000    0.059    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:102(_set_description)
   491000		0.058    0.000    0.058    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1765(isEnabledFor)
     1000		0.002    0.000    0.048    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:134(_set_footer)
     1000		0.001    0.000    0.041    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\case_block.py:44(process)
```