### PR TITLE
Fix oversight in _flush_text_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-*Currently none*
+- Remove redundant string join in the parser
 
 # v1.6.4
 

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -343,11 +343,7 @@ class TagScriptParser:
     def _flush_text_buffer(self) -> None:
         """Creates a text node from the current buffer if non-empty."""
         if len(self._text_buffer) > 0:
-            if len(self._text_buffer) == 1:
-                text = self._text_buffer[0]
-            else:
-                text = "".join(self._text_buffer)
-            self._nodes.append(Node.text(text_value=text))
+            self._nodes.append(Node.text(text_value=self._text_buffer))
             self._text_buffer = ""
 
 


### PR DESCRIPTION
Missed this in #27.

Performance-wise this appears to be negligibly positive (doing several profiling runs of `bench.py` always gets results in the range of [9.7s, 9.9s] which is basically what #27 got too.