### PR TITLE
Refactor parsing loop for easier readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-*Currently none*
+- Parsing loop refactor
 
 # v1.6.5 (2026-06-07)
 

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -68,7 +68,6 @@ class TagScriptParser:
                     i += 1
                 text = input_str[start:i]
                 self._text_buffer += text
-                char = input_str[i - 1] if i > 0 else ""
                 continue
 
             # mainly a typing crutch since current_state = block.state (top of loop)

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -23,7 +23,6 @@ COLON       = ":"
 
 
 _SPECIAL_TOKENS: set[str] = {
-    BACKSLASH,
     BRACE_OPEN,
     BRACE_CLOSE,
     PAREN_OPEN,

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -1,4 +1,5 @@
 import logging
+from typing import assert_never
 
 from ya_tagscript.interfaces import NodeABC
 
@@ -56,6 +57,7 @@ class TagScriptParser:
         char = ""
         while i < input_len:
             previous_char = char
+            is_escaped = previous_char == BACKSLASH
             char = input_str[i]
             block: BlockParseState | None = self._state
             current_state = block.state if block is not None else None
@@ -67,265 +69,184 @@ class TagScriptParser:
                     i += 1
                 text = input_str[start:i]
                 self._text_buffer += text
+                char = input_str[i - 1] if i > 0 else ""
                 continue
 
-            try:
+            # mainly a typing crutch since current_state = block.state (top of loop)
+            if block is None or current_state is None:
                 if char == BRACE_OPEN:
-                    # region Opening brace handling
-                    if block is None or current_state is None:
-                        if previous_char == BACKSLASH:
-                            # escaped, don't start block
-                            self._text_buffer += char
-                            i += 1
-                            continue
+                    if is_escaped:
+                        self._text_buffer += char
+                    else:
                         self._flush_text_buffer()
                         self._state = BlockParseState(
                             state=ParseState.EXPECTING_DECLARATION,
                             block_depth=1,
                         )
-                        i += 1
-                        continue
+                else:
+                    self._text_buffer += char
 
-                    if previous_char != BACKSLASH:
-                        block.block_depth += 1
-
-                    if current_state == ParseState.EXPECTING_DECLARATION:
-                        block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = char
-                    elif current_state == ParseState.IN_DECLARATION:
-                        if block.declaration is None:
-                            block.declaration = char
-                        else:
-                            block.declaration += char
-                    elif current_state == ParseState.IN_PARAMETER:
-                        if block.parameter is None:
-                            block.parameter = char
-                        else:
-                            block.parameter += char
-                    elif current_state == ParseState.IN_PAYLOAD:
-                        if block.payload is None:
-                            block.payload = char
-                        else:
-                            block.payload += char
-                    elif current_state == ParseState.POST_PARAMETER:
-                        # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer += _reconstruct_partial_block(block)
-                        self._text_buffer += char
-                        self._state = None
-                    # endregion Opening brace handling
-
+            elif current_state is ParseState.EXPECTING_DECLARATION:
+                # EXPECTING_DECLARATION is special:
+                # - previous_char _must_ have been "{" at 0-depth for block start
+                #   - is_escaped is always False
+                #   - block depth == 1, paren_depth == 0 guaranteed
+                # this is purely an assertion of this impossibility and thus not
+                # covered (or coverable!) by tests
+                if (
+                    is_escaped or block.block_depth != 1 or block.paren_depth != 0
+                ):  # pragma: no cover
+                    _log.error(
+                        (
+                            "EXPECTED_DECLARATION got "
+                            "is_escaped=%s, "
+                            "block_depth=%d, "
+                            "paren_depth=%r"
+                        ),
+                        is_escaped,
+                        block.block_depth,
+                        block.paren_depth,
+                    )
+                    raise AssertionError(
+                        (
+                            f"Invalid state in parser! EXPECTING_DECLARATION got: "
+                            f"{is_escaped=}, {block.block_depth=}, "
+                            f"{block.paren_depth=}"
+                        ),
+                    )
+                if char == BRACE_OPEN:
+                    # escaping is impossible in this state, must be nested block
+                    block.block_depth += 1
+                    block.transition_state(ParseState.IN_DECLARATION)
+                    block.declaration = char
                 elif char == BRACE_CLOSE:
-                    # region Closing brace handling
-                    if block is None or current_state is None:
-                        self._text_buffer += char
-                        i += 1
-                        continue
-                    elif block.block_depth == 1:
-                        if previous_char == BACKSLASH:
-                            if current_state == ParseState.IN_DECLARATION:
-                                if block.declaration is None:
-                                    block.declaration = char
-                                else:
-                                    block.declaration += char
-                            elif current_state == ParseState.IN_PARAMETER:
-                                if block.parameter is None:
-                                    block.parameter = char
-                                else:
-                                    block.parameter += char
-                            elif current_state == ParseState.IN_PAYLOAD:
-                                if block.payload is None:
-                                    block.payload = char
-                                else:
-                                    block.payload += char
-                            i += 1
-                            continue
-
-                        else:
-                            if current_state == ParseState.EXPECTING_DECLARATION:
-                                # {} found, illegal BLOCK node, treat as TEXT
-                                text = BRACE_OPEN + char
-                                self._text_buffer += text
-                            else:
-                                self._nodes.append(block.finalize())
-                            self._state = None
-                            i += 1
-                            continue
-
-                    if previous_char != BACKSLASH:
-                        block.block_depth -= 1
-
-                    if current_state == ParseState.EXPECTING_DECLARATION:
-                        block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = char
-                    elif current_state == ParseState.IN_DECLARATION:
-                        if block.declaration is None:
-                            block.declaration = char
-                        else:
-                            block.declaration += char
-                    elif current_state == ParseState.IN_PARAMETER:
-                        if block.parameter is None:
-                            block.parameter = char
-                        else:
-                            block.parameter += char
-                    elif current_state == ParseState.IN_PAYLOAD:
-                        if block.payload is None:
-                            block.payload = char
-                        else:
-                            block.payload += char
-                    elif current_state == ParseState.POST_PARAMETER:
-                        # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer += _reconstruct_partial_block(block)
-                        self._text_buffer += char
-                        self._state = None
-                    # endregion Closing brace handling
-
+                    # state guarantees: previous_char is "{" and block_depth == 1
+                    self._text_buffer += "{}"
+                    self._state = None
                 elif char == PAREN_OPEN:
-                    # region Opening paren handling
-                    if block is None or current_state is None:
-                        self._text_buffer += char
-                        i += 1
-                        continue
-
                     block.paren_depth += 1
-                    if current_state == ParseState.EXPECTING_DECLARATION:
-                        block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = char
-                    elif current_state == ParseState.IN_DECLARATION:
-                        if block.block_depth == 1:
-                            block.has_parameter_section = True
-                            block.transition_state(ParseState.IN_PARAMETER)
-                        elif block.declaration is None:
-                            block.declaration = char
-                        else:
-                            block.declaration += char
-                    elif current_state == ParseState.IN_PARAMETER:
-                        if block.parameter is None:
-                            block.parameter = char
-                        else:
-                            block.parameter += char
-                    elif current_state == ParseState.IN_PAYLOAD:
-                        if block.payload is None:
-                            block.payload = char
-                        else:
-                            block.payload += char
-                    elif current_state == ParseState.POST_PARAMETER:
-                        # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer += _reconstruct_partial_block(block)
-                        self._text_buffer += char
-                        self._state = None
-                    # endregion Opening paren handling
-
+                    block.transition_state(ParseState.IN_DECLARATION)
+                    block.declaration = char
                 elif char == PAREN_CLOSE:
-                    # region Closing paren handling
-                    if block is None or current_state is None:
-                        self._text_buffer += char
-                        i += 1
-                        continue
+                    block.transition_state(ParseState.IN_DECLARATION)
+                    block.declaration = char
+                    # state guarantee: paren_depth == 0, so can't decrement depth
+                else:
+                    # covers BACKSLASH, COLON, any other char
+                    block.transition_state(ParseState.IN_DECLARATION)
+                    block.declaration = char
 
-                    if current_state == ParseState.EXPECTING_DECLARATION:
-                        block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = char
-                    elif current_state == ParseState.IN_DECLARATION:
-                        if block.declaration is None:
-                            block.declaration = char
+            elif current_state is ParseState.IN_DECLARATION:
+                if char == BRACE_OPEN:
+                    if not is_escaped:
+                        block.block_depth += 1
+                    block.declaration = (block.declaration or "") + char
+                elif char == BRACE_CLOSE:
+                    if block.block_depth == 1:
+                        if is_escaped:
+                            block.declaration = (block.declaration or "") + char
                         else:
-                            block.declaration += char
-                    elif current_state == ParseState.IN_PARAMETER:
-                        if block.paren_depth == 1:
-                            block.transition_state(ParseState.POST_PARAMETER)
-                        elif block.parameter is None:
-                            block.parameter = char
-                        else:
-                            block.parameter += char
-                    elif current_state == ParseState.IN_PAYLOAD:
-                        if block.payload is None:
-                            block.payload = char
-                        else:
-                            block.payload += char
-                    elif current_state == ParseState.POST_PARAMETER:
-                        # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer += _reconstruct_partial_block(block)
-                        self._text_buffer += char
-                        self._state = None
-
-                    if block.paren_depth != 0:
+                            self._nodes.append(block.finalize())
+                            self._state = None
+                    else:
+                        if not is_escaped:
+                            block.block_depth -= 1
+                        block.declaration = (block.declaration or "") + char
+                elif char == PAREN_OPEN:
+                    block.paren_depth += 1
+                    if block.block_depth == 1:
+                        block.has_parameter_section = True
+                        block.transition_state(ParseState.IN_PARAMETER)
+                    else:
+                        block.declaration = (block.declaration or "") + char
+                elif char == PAREN_CLOSE:
+                    block.declaration = (block.declaration or "") + char
+                    if block.paren_depth > 0:
                         block.paren_depth -= 1
-                    # endregion Closing paren handling
-
                 elif char == COLON:
-                    # region Colon handling
-                    if block is None or current_state is None:
-                        self._text_buffer += char
-                        i += 1
-                        continue
-
-                    if current_state == ParseState.EXPECTING_DECLARATION:
-                        block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = char
-                    elif (
-                        current_state
-                        in (ParseState.IN_DECLARATION, ParseState.POST_PARAMETER)
-                        and block.block_depth == 1
-                    ):
-                        # end of declaration/post-parameter and beginning of payload
+                    if block.block_depth == 1:
                         block.has_payload_section = True
                         block.transition_state(ParseState.IN_PAYLOAD)
-                    elif current_state == ParseState.IN_DECLARATION:
-                        if block.declaration is None:
-                            block.declaration = char
-                        else:
-                            block.declaration += char
-                    elif current_state == ParseState.IN_PARAMETER:
-                        if block.parameter is None:
-                            block.parameter = char
-                        else:
-                            block.parameter += char
-                    elif current_state == ParseState.IN_PAYLOAD:
-                        if block.payload is None:
-                            block.payload = char
-                        else:
-                            block.payload += char
                     else:
-                        self._text_buffer += char
-                    # endregion Colon handling
-
+                        block.declaration = (block.declaration or "") + char
                 else:
-                    # region Any other char handling (including BACKSLASH)
-                    if block is None or current_state is None:
-                        # unlikely if not impossible to hit but better safe than sorry
-                        # (non-special chars are fast-tracked for None block above)
-                        self._text_buffer += char
-                        i += 1
-                        continue
+                    block.declaration = (block.declaration or "") + char
 
-                    if current_state == ParseState.EXPECTING_DECLARATION:
-                        block.transition_state(ParseState.IN_DECLARATION)
-                        block.declaration = char
-                    elif current_state == ParseState.IN_DECLARATION:
-                        if block.declaration is None:
-                            block.declaration = char
+            elif current_state is ParseState.IN_PARAMETER:
+                if char == BRACE_OPEN:
+                    if not is_escaped:
+                        block.block_depth += 1
+                    block.parameter = (block.parameter or "") + char
+                elif char == BRACE_CLOSE:
+                    if block.block_depth == 1:
+                        if is_escaped:
+                            block.parameter = (block.parameter or "") + char
                         else:
-                            block.declaration += char
-                    elif current_state == ParseState.IN_PARAMETER:
-                        if block.parameter is None:
-                            block.parameter = char
-                        else:
-                            block.parameter += char
-                    elif current_state == ParseState.IN_PAYLOAD:
-                        if block.payload is None:
-                            block.payload = char
-                        else:
-                            block.payload += char
-                    elif current_state == ParseState.POST_PARAMETER:
-                        # only colon or pop is allowed here, abort the block entirely
-                        self._text_buffer += _reconstruct_partial_block(block)
-                        self._text_buffer += char
-                        self._state = None
-                    # endregion Any other char handling (including BACKSLASH)
+                            # invalid block, abandon
+                            self._text_buffer += _reconstruct_partial_block(block)
+                            self._text_buffer += char
+                            self._state = None
+                    else:
+                        if not is_escaped:
+                            block.block_depth -= 1
+                        block.parameter = (block.parameter or "") + char
+                elif char == PAREN_OPEN:
+                    block.paren_depth += 1
+                    block.parameter = (block.parameter or "") + char
+                elif char == PAREN_CLOSE:
+                    if block.paren_depth == 1:
+                        block.transition_state(ParseState.POST_PARAMETER)
+                    else:
+                        block.parameter = (block.parameter or "") + char
+                    block.paren_depth -= 1
+                else:
+                    # includes BACKSLASH, COLON, any other char
+                    block.parameter = (block.parameter or "") + char
 
-            except ValueError as e:
-                _log.warning("Invalid state transition encountered: %r", e)
-                self._text_buffer += char
+            elif current_state is ParseState.POST_PARAMETER:
+                if char == BRACE_CLOSE and block.block_depth == 1:
+                    self._nodes.append(block.finalize())
+                    self._state = None
+                elif char == COLON and block.block_depth == 1:
+                    block.has_payload_section = True
+                    block.transition_state(ParseState.IN_PAYLOAD)
+                else:
+                    # by state guarantee
+                    # covers BRACE_OPEN, BRACE_CLOSE (higher depth), PAREN_OPEN,
+                    # PAREN_CLOSE, COLON (higher depth), BACKSLASH, any other char
+                    # only colon or pop is allowed here, abort the block entirely
+                    self._text_buffer += _reconstruct_partial_block(block)
+                    self._text_buffer += char
+                    self._state = None
+
+            elif current_state is ParseState.IN_PAYLOAD:
+                if char == BRACE_OPEN:
+                    if not is_escaped:
+                        block.block_depth += 1
+                    block.payload = (block.payload or "") + char
+                elif char == BRACE_CLOSE:
+                    if block.block_depth == 1:
+                        if is_escaped:
+                            block.payload = (block.payload or "") + char
+                        else:
+                            self._nodes.append(block.finalize())
+                            self._state = None
+                    else:
+                        if not is_escaped:
+                            block.block_depth -= 1
+                        block.payload = (block.payload or "") + char
+                elif char == PAREN_OPEN:
+                    block.paren_depth += 1
+                    block.payload = (block.payload or "") + char
+                elif char == PAREN_CLOSE:
+                    block.payload = (block.payload or "") + char
+                    if block.paren_depth > 0:
+                        block.paren_depth -= 1
+                else:
+                    # covers BACKSLASH, COLON, any other char
+                    block.payload = (block.payload or "") + char
+            else:
+                assert_never(current_state)
 
             i += 1
         # endregion end of processing loop
@@ -356,7 +277,9 @@ def _reconstruct_partial_block(block: BlockParseState) -> str:
         out += PAREN_OPEN
         if block.parameter is not None:
             out += block.parameter
-        out += PAREN_CLOSE
+        if block.state is not ParseState.IN_PARAMETER:
+            out += PAREN_CLOSE
+        # otherwise this is a block being abandoned mid-parameter, so no closing paren
     if block.has_payload_section:
         out += COLON
         if block.payload is not None:

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -96,17 +96,6 @@ class TagScriptParser:
                 if (
                     is_escaped or block.block_depth != 1 or block.paren_depth != 0
                 ):  # pragma: no cover
-                    _log.error(
-                        (
-                            "EXPECTED_DECLARATION got "
-                            "is_escaped=%s, "
-                            "block_depth=%d, "
-                            "paren_depth=%r"
-                        ),
-                        is_escaped,
-                        block.block_depth,
-                        block.paren_depth,
-                    )
                     raise AssertionError(
                         (
                             f"Invalid state in parser! EXPECTING_DECLARATION got: "

--- a/tests/ya_tagscript/interpreter/test_ts_parser.py
+++ b/tests/ya_tagscript/interpreter/test_ts_parser.py
@@ -262,3 +262,51 @@ def test_escaped_brace_pair_within_param_section_stays_in_param_without_becoming
         Node.block(declaration="dec", parameter=None, payload="\\{{var\\}}"),
         Node.block(declaration="second_dec", parameter=None, payload=None),
     ]
+
+
+def test_higher_block_depth_escaped_closing_brace(parser: TagScriptParser):
+    input_str = "{test{x\\}}}"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.block(declaration="test{x\\}}", parameter=None, payload=None),
+    ]
+
+
+def test_escaped_opening_brace_in_parameter(parser: TagScriptParser):
+    input_str = "{test(\\{x)}"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.block(declaration="test", parameter="\\{x", payload=None),
+    ]
+
+
+def test_closing_brace_in_unclosed_parameter_is_rejected(parser: TagScriptParser):
+    input_str = "{test(param}"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.text(text_value=input_str),
+    ]
+
+
+def test_higher_block_depth_escaped_closing_brace_in_parameter(parser: TagScriptParser):
+    input_str = "{test(param{a\\}})}"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.block(declaration="test", parameter="param{a\\}}", payload=None),
+    ]
+
+
+def test_higher_block_depth_post_param_is_rejected(parser: TagScriptParser):
+    input_str = "{test(param{x):}"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.text(text_value=input_str),
+    ]
+
+
+def test_lone_opening_brace_is_rejected(parser: TagScriptParser):
+    input_str = "{"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.text(text_value=input_str),
+    ]


### PR DESCRIPTION
This change inverts the parsing logic by checking state->char instead of char->state.

Changes are entirely compatible with no test changes, only new tests.

Also facilitated 100% branch coverage for the parsing loop by making the previous gaps in coverage easier to reason through.

Some minor performance gains showed up as well, though those weren't the point of this change.
- ~5% faster runtime (9.85s -> 9.39s)
- ~2% fewer function calls (10.9M -> 10.7M)
- ~6% less `tottime` for `parse()` (5.91s -> 5.53s)
- ~16% faster `cumtime` and `tottime` for `_flush_text_buffer()`, oddly enough (0.391s -> 0.327s and 0.196s -> 0.164s, respectively)

## Current `v1` (139bf1fa0487abcfda20f8bee0a085b6188dd8ed)
```console
> python .local\bench.py
         10986048 function calls (9365048 primitive calls) in 9.850 seconds

   Ordered by: cumulative time
   List reduced from 94 to 40 due to restriction	<40>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005    9.927    9.927	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.010    0.000    9.922    0.010	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000		0.383    0.000    9.911    0.005	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		5.910    0.000    6.962    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.348    0.000    5.743    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.336    0.000    5.519    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.201    0.000    5.015    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.086    0.000    4.809    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.080    0.000    2.598    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.084    0.000    1.499    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
4000/3000		0.003    0.000    0.723    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.018    0.000    0.593    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   447000		0.196    0.000    0.391    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:343(_flush_text_buffer)
   291000		0.138    0.000    0.373    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
108000/106000	0.087    0.000    0.326    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
     5000		0.013    0.000    0.273    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
   176000		0.188    0.000    0.259    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
   291000		0.194    0.000    0.236    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
     5000		0.003    0.000    0.230    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   876000		0.193    0.000    0.193    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000		0.117    0.000    0.175    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
    39000		0.150    0.000    0.167    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
115000/113000	0.061    0.000    0.157    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:50(will_accept)
   108000		0.051    0.000    0.143    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
1316000/1301000	0.113    0.000    0.130    0.000	{built-in method builtins.len}
     4000		0.007    0.000    0.129    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:63(process)
    55000		0.089    0.000    0.123    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:47(_find_zero_depth_operator)
     1000		0.003    0.000    0.112    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
   146000		0.092    0.000    0.111    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:69(text)
   291000		0.064    0.000    0.089    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:225(_check_workload)
   108000		0.045    0.000    0.080    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:64(_handle_ctx)
     1000		0.003    0.000    0.070    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\all_block.py:67(process)
   520001		0.065    0.000    0.065    0.000	{method 'append' of 'list' objects}
   405000		0.064    0.000    0.064    0.000	{method 'get' of 'dict' objects}
   488022		0.063    0.000    0.063    0.000	{method 'lower' of 'str' objects}
   437000		0.060    0.000    0.060    0.000	<string>:2(__init__)
     1000		0.000    0.000    0.059    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:102(_set_description)
   491000		0.058    0.000    0.058    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1765(isEnabledFor)
     1000		0.002    0.000    0.048    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:134(_set_footer)
     1000		0.001    0.000    0.041    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\case_block.py:44(process)
 ```
 
 ## Changes from this PR
```console
         10784048 function calls (9163048 primitive calls) in 9.394 seconds

   Ordered by: cumulative time
   List reduced from 93 to 40 due to restriction	<40>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005    9.471    9.471	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.010    0.000    9.465    0.009	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000		0.376    0.000    9.454    0.005	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		5.537    0.000    6.526    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.347    0.000    5.595    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.338    0.000    5.373    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.203    0.000    4.872    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.085    0.000    4.673    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.081    0.000    2.558    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.083    0.000    1.487    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
4000/3000		0.003    0.000    0.691    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.019    0.000    0.568    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.138    0.000    0.372    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   447000		0.164    0.000    0.327    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:251(_flush_text_buffer)
108000/106000	0.087    0.000    0.323    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:69(process)
     5000		0.013    0.000    0.268    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:444(process)
   176000		0.185    0.000    0.254    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
   291000		0.195    0.000    0.234    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
     5000		0.003    0.000    0.225    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:468(_update_embed)
   876000		0.196    0.000    0.196    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000		0.116    0.000    0.174    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
    39000		0.148    0.000    0.165    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
115000/113000	0.060    0.000    0.155    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:50(will_accept)
   108000		0.050    0.000    0.141    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
     4000		0.007    0.000    0.129    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:63(process)
    55000		0.088    0.000    0.122    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:47(_find_zero_depth_operator)
1170000/1155000	0.102    0.000    0.118    0.000	{built-in method builtins.len}
   146000		0.093    0.000    0.111    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:69(text)
     1000		0.004    0.000    0.110    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
   291000		0.064    0.000    0.089    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:225(_check_workload)
   108000		0.045    0.000    0.080    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:64(_handle_ctx)
     1000		0.003    0.000    0.070    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\all_block.py:67(process)
   520001		0.065    0.000    0.065    0.000	{method 'append' of 'list' objects}
   405000		0.063    0.000    0.063    0.000	{method 'get' of 'dict' objects}
   488022		0.062    0.000    0.062    0.000	{method 'lower' of 'str' objects}
   437000		0.058    0.000    0.058    0.000	<string>:2(__init__)
   491000		0.058    0.000    0.058    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1765(isEnabledFor)
     1000		0.000    0.000    0.057    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:102(_set_description)
     1000		0.002    0.000    0.047    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:134(_set_footer)
     1000		0.001    0.000    0.041    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\case_block.py:44(process)
 ```