### PR TITLE
Add codespell & flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E203, E266, E501
+max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,11 @@ default_language_version:
   python: python3.11
 fail_fast: false
 repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,13 @@ repos:
     hooks:
       - id: codespell
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-comprehensions==3.17.0
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 # v1.4.1 (2025-07-18)
 
 - Reject invalid syntax in `MathBlock`
-    - Blocks that contain invalid/unparseable syntax and cause pyparsing to raise a
+    - Blocks that contain invalid/unparsable syntax and cause pyparsing to raise a
       `ParseSyntaxException` are now rejected instead of throwing an exception into the
       interpreter
 

--- a/docs/_ext/glossary_backlink_checker.py
+++ b/docs/_ext/glossary_backlink_checker.py
@@ -83,7 +83,7 @@ class GlossaryRefChecker:
                 anchor = f"auto-ref-{hash(node.astext()) % 100000}"
 
             _logger.verbose(
-                f"[GlossaryRefCheck] Glossary term reference found: term=%r, doc=%r, anchor=%r",
+                "[GlossaryRefCheck] Glossary term reference found: term=%r, doc=%r, anchor=%r",
                 term,
                 docname,
                 anchor,

--- a/make_release.py
+++ b/make_release.py
@@ -325,16 +325,16 @@ def main():
     if (match := re.match(r"(\d+\.\d+\.\d+)([ab]\d+)?", current_version)) is None:
         raise ValueError("Current project version does not match SemVer, exiting...")
 
-    _log.debug(f"current_version=%r", current_version)
+    _log.debug("current_version=%r", current_version)
 
     main_semver = match.group(1)
-    _log.debug(f"main_semver=%r", main_semver)
+    _log.debug("main_semver=%r", main_semver)
 
     current_prerelease_section = match.group(2)
-    _log.debug(f"current_prerelease_section=%r", current_prerelease_section)
+    _log.debug("current_prerelease_section=%r", current_prerelease_section)
 
     currently_is_full_release = current_prerelease_section is None
-    _log.debug(f"currently_is_full_release=%r", currently_is_full_release)
+    _log.debug("currently_is_full_release=%r", currently_is_full_release)
 
     if args.create_tag:
         if not currently_is_full_release:
@@ -379,7 +379,7 @@ def main():
     else:
         raise RuntimeError("Missing bump type (must be one of alpha|patch|minor|major)")
 
-    _log.debug(f"new_version=%r", new_version)
+    _log.debug("new_version=%r", new_version)
 
     if args.interactive:
         approved = input(f"New version will be {new_version!r}. Proceed? (Y/n) ")

--- a/src/ya_tagscript/blocks/math/ordinal_block.py
+++ b/src/ya_tagscript/blocks/math/ordinal_block.py
@@ -19,8 +19,8 @@ class OrdinalBlock(BlockABC):
     If a parameter is provided, it must be one of the following:
 
     - ``c`` or ``comma``: Adds commas as thousands separators but no indicator
-    - ``i`` or ``indicator``: Appends the ordinal indicator (e.g., ``st`` for 1st,
-      ``nd`` for 2nd) but does not include commas as thousands separators
+    - ``i`` or ``indicator``: Appends the ordinal indicator (e.g., ``-st`` for 1st,
+      ``-nd`` for 2nd) but does not include commas as thousands separators
 
     **Usage**: ``{ord(["c"|"comma"|"i"|"indicator"]):<number>}``
 

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -13,12 +13,12 @@ _log = logging.getLogger(__name__)
 
 
 # fmt: off
-BACKSLASH   = "\\"
-BRACE_OPEN  = "{"
+BACKSLASH   = "\\"  # noqa: E221
+BRACE_OPEN  = "{"  # noqa: E221
 BRACE_CLOSE = "}"
-PAREN_OPEN  = "("
+PAREN_OPEN  = "("  # noqa: E221
 PAREN_CLOSE = ")"
-COLON       = ":"
+COLON       = ":"  # noqa: E221
 # fmt: on
 
 

--- a/src/ya_tagscript/util/conditionals.py
+++ b/src/ya_tagscript/util/conditionals.py
@@ -26,7 +26,7 @@ def parse_condition(ctx: Context, condition: str) -> bool | None:
         condition[found_op.end_idx :],
     )
     _log.debug(
-        f"Requested expression: %r %r %r",
+        "Requested expression: %r %r %r",
         left_cond,
         found_op,
         right_cond,

--- a/tests/ya_tagscript/adapters/discord_adapters/test_guild_adapter.py
+++ b/tests/ya_tagscript/adapters/discord_adapters/test_guild_adapter.py
@@ -221,7 +221,7 @@ def test_random_member_getter_is_supported(
     obj = MagicMock(discord.Guild, members=member_list)
     data = {"my_guild": adapters.GuildAdapter(obj)}
     result = ts_interpreter.process(script, data).body
-    assert result in list(map(lambda m: str(m), member_list))
+    assert result in [str(m) for m in member_list]
     assert result != member_list
 
 

--- a/tests/ya_tagscript/blocks/discord/test_embed_block.py
+++ b/tests/ya_tagscript/blocks/discord/test_embed_block.py
@@ -123,7 +123,7 @@ def test_dec_embed_docs_example_one(
     assert len(embed.fields) == 1
     assert embed.fields[0].name == "Rule 1"
     assert embed.fields[0].value == "Respect everyone you speak to."
-    assert embed.fields[0].inline == False
+    assert embed.fields[0].inline is False
     assert isinstance(embed.timestamp, datetime)
     assert int(embed.timestamp.timestamp()) == 1681234567
 
@@ -167,7 +167,7 @@ def test_dec_embed_docs_example_four(
     assert len(embed.fields) == 1
     assert embed.fields[0].name == "Field 1"
     assert embed.fields[0].value == "field description"
-    assert embed.fields[0].inline == False
+    assert embed.fields[0].inline is False
     assert embed.title == "my embed title"
 
 

--- a/tests/ya_tagscript/blocks/math/test_ordinal_block.py
+++ b/tests/ya_tagscript/blocks/math/test_ordinal_block.py
@@ -211,7 +211,7 @@ def test_dec_ord_with_indicator_param_returns_correct_ordinals_10_000_to_10_100(
 def test_dec_ord_with_c_param_returns_separated_number_without_ordinals(
     ts_interpreter: TagScriptInterpreter,
 ):
-    # this has thousands separators but no ordinal indicators (st, nd, rd, th)
+    # this has thousands separators but no ordinal indicators (-st, -nd, -rd, -th)
     for i, n in enumerate(_NUMBERS_10000_TO_10100_WITH_COMMAS, start=10_000):
         script = f"{{ord(c):{i}}}"
         result = ts_interpreter.process(script).body
@@ -221,7 +221,7 @@ def test_dec_ord_with_c_param_returns_separated_number_without_ordinals(
 def test_dec_ord_with_comma_param_returns_separated_number_without_ordinals(
     ts_interpreter: TagScriptInterpreter,
 ):
-    # this has thousands separators but no ordinal indicators (st, nd, rd, th)
+    # this has thousands separators but no ordinal indicators (-st, -nd, -rd, -th)
     for i, n in enumerate(_NUMBERS_10000_TO_10100_WITH_COMMAS, start=10_000):
         script = f"{{ord(comma):{i}}}"
         result = ts_interpreter.process(script).body


### PR DESCRIPTION
Codespell:
- Ordinal suffixes triggered warnings, so they're now marked with a hyphen.

Flake8:
Ignoring:
- "whitespace before operator" warnings (E203)
  - these occur around expressions in slicing operations
- line length warnings (E501)
  - a lot of them end up being long links or scripts in docstrings that can't easily be ignored
- "Too many # for block comment" (E266)
  - these comments are markers for make_release.py's replacing logic