### PR TITLE
Reject inputs early in `Context.interpret_segment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-*Currently none*
+- Minor interpretation optimizations
 
 # v1.6.7 (2026-06-08)
 

--- a/src/ya_tagscript/interpreter/context.py
+++ b/src/ya_tagscript/interpreter/context.py
@@ -40,6 +40,8 @@ class Context:
         str
             The fully interpreted result string
         """
+        if not ("{" in string) or not ("}" in string):
+            return string
         # noinspection PyProtectedMember
         return self.interpreter._interpret(  # pyright: ignore [reportPrivateUsage]
             subject=string,


### PR DESCRIPTION
The same check is also performed in the `interpreter._interpret()` call but earlier saves a bit of time and some function call overhead.

Tiny bit of performance gain of 100-200ms across `bench.py` runs.
- ~75% reduction in recursive calls to `_interpret` (685k / 2k (683k recursive) -> 169k / 2k (167k recursive)) (total/primitive)
- ~18% faster `tottime` (0.379s -> 0.311s) in `Interpreter._interpret()`
- ~2% faster runtime (9.423s -> 9.266s)
- ~5% fewer function calls (10.7M -> 10.2M)
- ~14% faster `cumtime` for `StrictVariableGetterBlock.process` (0.322s -> 0.277s) (similar gains expected for `LooseVariableGetterBlock` but that is not used in `bench.py`)

## Current `v1` (70250edd3a8d17ce1952b0b904ba97b2425fadf2)
```console
> python .local\bench.py
         10784048 function calls (9163048 primitive calls) in 9.423 seconds

   Ordered by: cumulative time
   List reduced from 93 to 40 due to restriction	<40>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005    9.500    9.500	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.011    0.000    9.494    0.009	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
685000/2000		0.379    0.000    9.482    0.005	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		5.557    0.000    6.545    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.348    0.000    5.610    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.336    0.000    5.387    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.201    0.000    4.887    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.084    0.000    4.685    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.080    0.000    2.564    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.084    0.000    1.491    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
4000/3000		0.003    0.000    0.696    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.019    0.000    0.571    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.137    0.000    0.372    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   447000		0.163    0.000    0.325    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:252(_flush_text_buffer)
108000/106000	0.086    0.000    0.322    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:70(process)
     5000		0.013    0.000    0.271    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:445(process)
   176000		0.189    0.000    0.256    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
   291000		0.194    0.000    0.234    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
     5000		0.003    0.000    0.226    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:470(_update_embed)
   876000		0.196    0.000    0.196    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000		0.117    0.000    0.175    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
    39000		0.149    0.000    0.166    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
115000/113000	0.059    0.000    0.154    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:50(will_accept)
   108000		0.050    0.000    0.142    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
     4000		0.007    0.000    0.129    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:63(process)
    55000		0.089    0.000    0.123    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:48(_find_zero_depth_operator)
1170000/1155000	0.103    0.000    0.120    0.000	{built-in method builtins.len}
   146000		0.092    0.000    0.110    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:69(text)
     1000		0.003    0.000    0.110    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
   291000		0.064    0.000    0.089    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:225(_check_workload)
   108000		0.045    0.000    0.080    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:64(_handle_ctx)
     1000		0.003    0.000    0.070    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\all_block.py:67(process)
   520001		0.065    0.000    0.065    0.000	{method 'append' of 'list' objects}
   405000		0.064    0.000    0.064    0.000	{method 'get' of 'dict' objects}
   488022		0.063    0.000    0.063    0.000	{method 'lower' of 'str' objects}
   437000		0.058    0.000    0.058    0.000	<string>:2(__init__)
   491000		0.058    0.000    0.058    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1765(isEnabledFor)
     1000		0.000    0.000    0.058    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:102(_set_description)
     1000		0.002    0.000    0.047    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:134(_set_footer)
     1000		0.001    0.000    0.041    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\case_block.py:44(process)
```
## Changes in this PR
```console
> python .local\bench.py
         10268048 function calls (9163048 primitive calls) in 9.266 seconds

   Ordered by: cumulative time
   List reduced from 93 to 40 due to restriction	<40>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005    9.342    9.342	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.010    0.000    9.337    0.009	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
169000/2000		0.311    0.000    9.326    0.005	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		5.570    0.000    6.552    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.343    0.000    5.438    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.331    0.000    5.218    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.131    0.000    4.724    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.084    0.000    4.533    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:39(process)
53000/49000		0.079    0.000    2.465    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:87(process)
55000/53000		0.084    0.000    1.421    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:15(parse_condition)
4000/3000		0.003    0.000    0.686    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:38(process)
10000/1000		0.018    0.000    0.565    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:48(process)
   291000		0.137    0.000    0.367    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   447000		0.163    0.000    0.324    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:252(_flush_text_buffer)
108000/106000	0.086    0.000    0.277    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:70(process)
     5000		0.013    0.000    0.260    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:445(process)
   176000		0.185    0.000    0.252    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:94(will_accept)
   291000		0.190    0.000    0.230    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
     5000		0.003    0.000    0.219    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:470(_update_embed)
   876000		0.197    0.000    0.197    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000		0.116    0.000    0.174    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
    39000		0.149    0.000    0.166    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
   108000		0.050    0.000    0.126    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
     4000		0.007    0.000    0.122    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:63(process)
    55000		0.087    0.000    0.121    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:48(_find_zero_depth_operator)
1170000/1155000	0.103    0.000    0.119    0.000	{built-in method builtins.len}
115000/113000	0.060    0.000    0.117    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:50(will_accept)
   146000		0.090    0.000    0.108    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:69(text)
     1000		0.003    0.000    0.107    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
   291000		0.064    0.000    0.089    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:225(_check_workload)
     1000		0.003    0.000    0.068    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\all_block.py:67(process)
   520001		0.066    0.000    0.066    0.000	{method 'append' of 'list' objects}
   108000		0.043    0.000    0.065    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:64(_handle_ctx)
   488022		0.063    0.000    0.063    0.000	{method 'lower' of 'str' objects}
   405000		0.063    0.000    0.063    0.000	{method 'get' of 'dict' objects}
   437000		0.058    0.000    0.058    0.000	<string>:2(__init__)
   491000		0.058    0.000    0.058    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1765(isEnabledFor)
     1000		0.000    0.000    0.056    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:102(_set_description)
     1000		0.002    0.000    0.046    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:134(_set_footer)
     1000		0.001    0.000    0.040    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\case_block.py:44(process)
```