### PR TITLE
Fix bug in split_at_substring_zero_depth with partially repeated longer needles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Fix bug in `split_at_substring_zero_depth` where a partially repeated needle of size
+  2 or longer would be counted as another needle occurrence.
+    - This bug did not affect any library uses of the helper since all needles are 1
+      character long
 - Minor interpretation optimizations
 
 # v1.6.7 (2026-06-08)
@@ -27,7 +31,7 @@
 # v1.6.2 (2026-05-16)
 
 - Fix import structure
-  - This should have no user-facing consequences as it was a purely internal change.
+    - This should have no user-facing consequences as it was a purely internal change.
 - Include tests in coverage
 - Start testing on 3.15-beta
 - Stricter type checking

--- a/src/ya_tagscript/util/splitter.py
+++ b/src/ya_tagscript/util/splitter.py
@@ -14,7 +14,8 @@ def split_at_substring_zero_depth(
     needle_len = len(needle)  # Calculate length once
     haystack_len = len(haystack)  # Calculate length once
 
-    for i in range(haystack_len):
+    i = 0
+    while i < haystack_len:
         char = haystack[i]
 
         # Update nesting depth
@@ -27,13 +28,15 @@ def split_at_substring_zero_depth(
         elif (
             depth == 0
             and (max_split < 0 or splits < max_split)
-            and i + needle_len <= haystack_len  # Boundary check
             and haystack[i : i + needle_len] == needle
         ):
             result.append(haystack[start_idx:i])
             start_idx = i + needle_len
             splits += 1
-            i += needle_len - 1  # Skip ahead, but -1 because the loop will increment i
+            i += needle_len  # Skip ahead
+            continue
+
+        i += 1
 
     # Add the final segment
     result.append(haystack[start_idx:])

--- a/tests/ya_tagscript/util/test_splitter.py
+++ b/tests/ya_tagscript/util/test_splitter.py
@@ -65,3 +65,11 @@ def test_do_not_discard_empty_out_elements_from_successive_needle_occurrences():
         "",        "",
     ]
     # fmt: on
+
+
+def test_partially_repeated_longer_needle():
+    haystack = "test--needles--longer---than--one"
+    needle = "--"
+    out = split_at_substring_zero_depth(haystack, needle)
+    assert len(out) == 5
+    assert out == ["test", "needles", "longer", "-than", "one"]


### PR DESCRIPTION
The skip-ahead in the haystack iteration had no effect because `for` loops reassign the loop variable without keeping any changes. A `while` loop does not have this issue.