### PR TITLE
Replace _accepted_names with _VALID_NAMES attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-- The `_accepted_names` block property has been deprecated and is scheduled for removal
-  in 2.0. Use the newly introduced `_VALID_NAMES` attribute instead.
+- The `_accepted_names` block property has been **deprecated** and is scheduled for
+  removal in 2.0. Use the newly introduced `_VALID_NAMES` attribute instead.
     - `_accepted_names` is now a shim around `_VALID_NAMES` and no longer an
       `@abstractmethod`.
 - Fix bug in `split_at_substring_zero_depth` where a partially repeated needle of size

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- The `_accepted_names` block property has been deprecated and is scheduled for removal
+  in 2.0. Use the newly introduced `_VALID_NAMES` attribute instead.
+    - `_accepted_names` is now a shim around `_VALID_NAMES` and no longer an
+      `@abstractmethod`.
 - Fix bug in `split_at_substring_zero_depth` where a partially repeated needle of size
   2 or longer would be counted as another needle occurrence.
     - This bug did not affect any library uses of the helper since all needles are 1

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -20,7 +20,7 @@ For example, the concrete :class:`~ya_tagscript.interpreter.TagScriptInterpreter
 
 .. autoclass:: BlockABC
     :members:
-    :private-members: _accepted_names
+    :private-members: _accepted_names, _VALID_NAMES
     :no-show-inheritance:
 
 .. autoclass:: InterpreterABC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ reportUnknownVariableType = "none"
 filterwarnings = [
     "error",
     'ignore:.audioop. is deprecated and slated for removal in Python 3.13:DeprecationWarning',
+    'ignore:Deprecated since v1.7. Use _VALID_NAMES instead:DeprecationWarning'
 ]
 
 [tool.tox]

--- a/src/ya_tagscript/blocks/actions/command_block.py
+++ b/src/ya_tagscript/blocks/actions/command_block.py
@@ -40,14 +40,12 @@ class CommandBlock(BlockABC):
         *up to the client* to implement actual command execution behaviour as desired.
     """
 
+    _VALID_NAMES = {"c", "com", "cmd", "command"}
+
     requires_nonempty_payload = True
 
     def __init__(self, limit: int = 3) -> None:
         self.limit = limit
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"c", "com", "cmd", "command"}
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/actions/delete_block.py
+++ b/src/ya_tagscript/blocks/actions/delete_block.py
@@ -53,9 +53,7 @@ class DeleteBlock(BlockABC):
         deletion behaviour as desired.
     """
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"delete", "del"}
+    _VALID_NAMES = {"delete", "del"}
 
     def process(self, ctx: Context) -> str | None:
         if "delete" in ctx.response.actions.keys():

--- a/src/ya_tagscript/blocks/actions/override_block.py
+++ b/src/ya_tagscript/blocks/actions/override_block.py
@@ -52,9 +52,7 @@ class OverrideBlock(BlockABC):
         what permissions qualify for "admin", "mod", or "permissions".
     """
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"override"}
+    _VALID_NAMES = {"override"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/actions/react_block.py
+++ b/src/ya_tagscript/blocks/actions/react_block.py
@@ -71,14 +71,12 @@ class ReactBlock(BlockABC):
         behaviour as desired.
     """
 
+    _VALID_NAMES = {"react", "reactu"}
+
     requires_nonempty_payload = True
 
     def __init__(self, limit: int = 5) -> None:
         self.limit = limit
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"react", "reactu"}
 
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration

--- a/src/ya_tagscript/blocks/actions/redirect_block.py
+++ b/src/ya_tagscript/blocks/actions/redirect_block.py
@@ -57,11 +57,9 @@ class RedirectBlock(BlockABC):
         and reject channel names, for example).
     """
 
-    requires_nonempty_parameter = False
+    _VALID_NAMES = {"redirect"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"redirect"}
+    requires_nonempty_parameter = False
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/actions/silence_block.py
+++ b/src/ya_tagscript/blocks/actions/silence_block.py
@@ -44,9 +44,7 @@ class SilenceBlock(BlockABC):
         this is **not** recommended.
     """
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"silent", "silence"}
+    _VALID_NAMES = {"silent", "silence"}
 
     def process(self, ctx: Context) -> str | None:
         ctx.response.actions["silent"] = True

--- a/src/ya_tagscript/blocks/conditional/all_block.py
+++ b/src/ya_tagscript/blocks/conditional/all_block.py
@@ -57,12 +57,10 @@ class AllBlock(BlockABC):
 
     """
 
+    _VALID_NAMES = {"all", "and"}
+
     requires_nonempty_parameter = True
     requires_nonempty_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"all", "and"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/conditional/any_block.py
+++ b/src/ya_tagscript/blocks/conditional/any_block.py
@@ -57,12 +57,10 @@ class AnyBlock(BlockABC):
 
     """
 
+    _VALID_NAMES = {"any", "or"}
+
     requires_nonempty_parameter = True
     requires_nonempty_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"any", "or"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/conditional/if_block.py
+++ b/src/ya_tagscript/blocks/conditional/if_block.py
@@ -77,12 +77,10 @@ class IfBlock(BlockABC):
     +------------+--------------------------+---------+---------------------------------------------+
     """
 
+    _VALID_NAMES = {"if"}
+
     requires_nonempty_parameter = True
     requires_nonempty_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"if"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/discord/cooldown_block.py
+++ b/src/ya_tagscript/blocks/discord/cooldown_block.py
@@ -47,6 +47,8 @@ class CooldownBlock(BlockABC):
         # Slow down! This tag can only be used 3 times per 3 seconds per channel. Try again in **0.74** seconds.
     """
 
+    _VALID_NAMES = {"cooldown"}
+
     requires_nonempty_parameter = True
     requires_nonempty_payload = True
 
@@ -62,10 +64,6 @@ class CooldownBlock(BlockABC):
         cooldown = commands.CooldownMapping.from_cooldown(rate, per, lambda x: x)
         cls.COOLDOWNS[key] = cooldown
         return cooldown
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"cooldown"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/discord/embed_block.py
+++ b/src/ya_tagscript/blocks/discord/embed_block.py
@@ -424,6 +424,8 @@ class EmbedBlock(BlockABC):
         client* to actually send the :class:`discord.Embed` object being constructed.
     """
 
+    _VALID_NAMES = {"embed"}
+
     ATTRIBUTE_HANDLERS: dict[str, Callable[[Context, Embed, str, str | None], None]] = {
         "author": _set_author,
         "description": _set_description,
@@ -437,10 +439,6 @@ class EmbedBlock(BlockABC):
         "footer": _set_footer,
         "timestamp": _set_timestamp,
     }
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"embed"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/flow/break_block.py
+++ b/src/ya_tagscript/blocks/flow/break_block.py
@@ -34,11 +34,9 @@ class BreakBlock(BlockABC):
         {break({args}==):You did not provide any input.}
     """
 
-    requires_any_parameter = True
+    _VALID_NAMES = {"break", "short", "shortcircuit"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"break", "short", "shortcircuit"}
+    requires_any_parameter = True
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/flow/shortcutredirect_block.py
+++ b/src/ya_tagscript/blocks/flow/shortcutredirect_block.py
@@ -33,12 +33,10 @@ class ShortcutRedirectBlock(BlockABC):
         # hello
     """
 
+    _VALID_NAMES = set()
+
     def __init__(self, shortcut_for: str) -> None:
         self.redirect_name = shortcut_for
-
-    @property
-    def _accepted_names(self) -> None:
-        return None
 
     def will_accept(self, ctx: Context) -> bool:
         """

--- a/src/ya_tagscript/blocks/flow/stop_block.py
+++ b/src/ya_tagscript/blocks/flow/stop_block.py
@@ -38,11 +38,9 @@ class StopBlock(BlockABC):
         # Enforces providing arguments for a tag
     """
 
-    requires_nonempty_parameter = True
+    _VALID_NAMES = {"stop", "halt", "error"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"stop", "halt", "error"}
+    requires_nonempty_parameter = True
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/limiters/blacklist_block.py
+++ b/src/ya_tagscript/blocks/limiters/blacklist_block.py
@@ -59,11 +59,9 @@ class BlacklistBlock(BlockABC):
         tag execution is blacklisted somehow.
     """
 
-    requires_nonempty_parameter = True
+    _VALID_NAMES = {"blacklist"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"blacklist"}
+    requires_nonempty_parameter = True
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/limiters/require_block.py
+++ b/src/ya_tagscript/blocks/limiters/require_block.py
@@ -61,11 +61,9 @@ class RequireBlock(BlockABC):
         the tag execution does not meet the requirements and is therefore blocked.
     """
 
-    requires_nonempty_parameter = True
+    _VALID_NAMES = {"require", "whitelist"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"require", "whitelist"}
+    requires_nonempty_parameter = True
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/lists/cycle_block.py
+++ b/src/ya_tagscript/blocks/lists/cycle_block.py
@@ -42,12 +42,10 @@ class CycleBlock(BlockABC):
         The block no longer has a ":term:`zero-depth`" restriction (see Caution above)
     """
 
+    _VALID_NAMES = {"cycle"}
+
     requires_nonempty_parameter = True
     requires_any_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"cycle"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/lists/list_block.py
+++ b/src/ya_tagscript/blocks/lists/list_block.py
@@ -40,12 +40,10 @@ class ListBlock(BlockABC):
         The block no longer has a ":term:`zero-depth`" restriction (see Caution above)
     """
 
+    _VALID_NAMES = {"list"}
+
     requires_nonempty_parameter = True
     requires_any_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"list"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/math/math_block.py
+++ b/src/ya_tagscript/blocks/math/math_block.py
@@ -335,12 +335,10 @@ class MathBlock(BlockABC):
     If you're curious, here is :ref:`the Numeric String Parser`.
     """
 
+    _VALID_NAMES = {"math", "m", "+", "calc"}
+
     _NSP = NumericStringParser()
     requires_nonempty_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"math", "m", "+", "calc"}
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/math/ordinal_block.py
+++ b/src/ya_tagscript/blocks/math/ordinal_block.py
@@ -42,11 +42,9 @@ class OrdinalBlock(BlockABC):
         # Returns: 2022nd
     """
 
-    requires_nonempty_payload = True
+    _VALID_NAMES = {"o", "ord"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"o", "ord"}
+    requires_nonempty_payload = True
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/meta/comment_block.py
+++ b/src/ya_tagscript/blocks/meta/comment_block.py
@@ -39,9 +39,7 @@ class CommentBlock(BlockABC):
         # comment block
     """
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"/", "//", "comment"}
+    _VALID_NAMES = {"/", "//", "comment"}
 
     def process(self, ctx: Context) -> str:
         return ""

--- a/src/ya_tagscript/blocks/meta/debug_block.py
+++ b/src/ya_tagscript/blocks/meta/debug_block.py
@@ -96,9 +96,7 @@ class DebugBlock(BlockABC):
         if this is desired.
     """
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"debug"}
+    _VALID_NAMES = {"debug"}
 
     def process(self, ctx: Context) -> str | None:
         debug: dict[str, str | None] = {}

--- a/src/ya_tagscript/blocks/rng/fiftyfifty_block.py
+++ b/src/ya_tagscript/blocks/rng/fiftyfifty_block.py
@@ -23,11 +23,9 @@ class FiftyFiftyBlock(BlockABC):
         # I pick heads! (50% chance)
     """
 
-    requires_any_payload = True
+    _VALID_NAMES = {"5050", "50", "?"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"5050", "50", "?"}
+    requires_any_payload = True
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/rng/random_block.py
+++ b/src/ya_tagscript/blocks/rng/random_block.py
@@ -54,11 +54,9 @@ class RandomBlock(BlockABC):
         # good morning
     """
 
-    requires_nonempty_payload = True
+    _VALID_NAMES = {"random", "rand", "#"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"random", "rand", "#"}
+    requires_nonempty_payload = True
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/rng/range_block.py
+++ b/src/ya_tagscript/blocks/rng/range_block.py
@@ -51,7 +51,11 @@ class RangeBlock(BlockABC):
 
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration
-        if declaration is None or declaration not in self._accepted_names:
+        # go via _accepted_names to preserve compatibility during the deprecation
+        valid_names = (
+            self._accepted_names if self._accepted_names is not None else set()
+        )
+        if declaration is None or declaration not in valid_names:
             return None
 
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/rng/range_block.py
+++ b/src/ya_tagscript/blocks/rng/range_block.py
@@ -51,7 +51,7 @@ class RangeBlock(BlockABC):
 
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration
-        if declaration is None or declaration not in self._VALID_NAMES:
+        if declaration is None or declaration not in self._accepted_names:
             return None
 
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/rng/range_block.py
+++ b/src/ya_tagscript/blocks/rng/range_block.py
@@ -43,17 +43,15 @@ class RangeBlock(BlockABC):
         # I am guessing your height is 5.3ft.
     """
 
+    _VALID_NAMES = {"range", "rangef"}
+
     _PRECISION = 1_000_000_000_000_000  # 1e15
 
     requires_nonempty_payload = True
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"range", "rangef"}
-
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration
-        if declaration is None or declaration not in self._accepted_names:
+        if declaration is None or declaration not in self._VALID_NAMES:
             return None
 
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/strings/case_block.py
+++ b/src/ya_tagscript/blocks/strings/case_block.py
@@ -35,11 +35,9 @@ class CaseBlock(BlockABC):
         # I AM TALKING.
     """
 
-    requires_any_payload = True
+    _VALID_NAMES = {"lower", "upper"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"lower", "upper"}
+    requires_any_payload = True
 
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration

--- a/src/ya_tagscript/blocks/strings/join_block.py
+++ b/src/ya_tagscript/blocks/strings/join_block.py
@@ -28,12 +28,10 @@ class JoinBlock(BlockABC):
         # Icanmasqueradeasaconcatblock
     """
 
+    _VALID_NAMES = {"join"}
+
     requires_any_parameter = True
     requires_any_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"join"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/strings/python_block.py
+++ b/src/ya_tagscript/blocks/strings/python_block.py
@@ -53,12 +53,10 @@ class PythonBlock(BlockABC):
         very few users.
     """
 
+    _VALID_NAMES = {"contains", "in", "index"}
+
     requires_any_parameter = True
     requires_any_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"contains", "in", "index"}
 
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration

--- a/src/ya_tagscript/blocks/strings/replace_block.py
+++ b/src/ya_tagscript/blocks/strings/replace_block.py
@@ -38,12 +38,10 @@ class ReplaceBlock(BlockABC):
         # An amazing Cadi ba
     """
 
+    _VALID_NAMES = {"replace"}
+
     requires_nonempty_parameter = True
     requires_nonempty_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"replace"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/strings/substring_block.py
+++ b/src/ya_tagscript/blocks/strings/substring_block.py
@@ -46,12 +46,10 @@ class SubstringBlock(BlockABC):
         # hello world
     """
 
+    _VALID_NAMES = {"substring", "substr"}
+
     requires_nonempty_parameter = True
     requires_nonempty_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"substring", "substr"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/strings/urldecode_block.py
+++ b/src/ya_tagscript/blocks/strings/urldecode_block.py
@@ -37,11 +37,9 @@ class URLDecodeBlock(BlockABC):
         # this+will+keep+the+plus+signs
     """
 
-    requires_any_payload = True
+    _VALID_NAMES = {"urldecode"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"urldecode"}
+    requires_any_payload = True
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/strings/urlencode_block.py
+++ b/src/ya_tagscript/blocks/strings/urlencode_block.py
@@ -35,11 +35,9 @@ class URLEncodeBlock(BlockABC):
         # <https://ya-tagscript.readthedocs.io/en/latest/search.html?q=command+block&check_keywords=yes&area=default>
     """
 
-    requires_any_payload = True
+    _VALID_NAMES = {"urlencode"}
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"urlencode"}
+    requires_any_payload = True
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/time/strf_block.py
+++ b/src/ya_tagscript/blocks/time/strf_block.py
@@ -62,9 +62,7 @@ class StrfBlock(BlockABC):
         # (this is 2000-01-01T00:00:00+00:00)
     """
 
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"strf", "unix"}
+    _VALID_NAMES = {"strf", "unix"}
 
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration

--- a/src/ya_tagscript/blocks/time/timedelta_block.py
+++ b/src/ya_tagscript/blocks/time/timedelta_block.py
@@ -57,6 +57,8 @@ class TimedeltaBlock(BlockABC):
         # 1 hour and 30 minutes
     """
 
+    _VALID_NAMES = {"timedelta", "td"}
+
     requires_nonempty_payload = True
 
     def __init__(
@@ -83,10 +85,6 @@ class TimedeltaBlock(BlockABC):
             self._humanize_fn = time_humanize_fn
         else:
             self._humanize_fn = self._timedelta_humanize
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"timedelta", "td"}
 
     def process(self, ctx: Context) -> str | None:
         payload = ctx.node.payload

--- a/src/ya_tagscript/blocks/variables/assign_block.py
+++ b/src/ya_tagscript/blocks/variables/assign_block.py
@@ -29,12 +29,10 @@ class AssignmentBlock(BlockABC):
         # The day is Monday.
     """
 
+    _VALID_NAMES = {"=", "assign", "let", "var"}
+
     requires_any_parameter = True
     requires_any_payload = True
-
-    @property
-    def _accepted_names(self) -> set[str]:
-        return {"=", "assign", "let", "var"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter

--- a/src/ya_tagscript/blocks/variables/loose_variable_getter_block.py
+++ b/src/ya_tagscript/blocks/variables/loose_variable_getter_block.py
@@ -45,9 +45,7 @@ class LooseVariableGetterBlock(BlockABC):
             :class:`~ya_tagscript.adapters.StringAdapter` documentation).
     """
 
-    @property
-    def _accepted_names(self) -> None:
-        return None
+    _VALID_NAMES = set()
 
     def will_accept(self, ctx: Context) -> Literal[True]:
         """

--- a/src/ya_tagscript/blocks/variables/strict_variable_getter_block.py
+++ b/src/ya_tagscript/blocks/variables/strict_variable_getter_block.py
@@ -43,9 +43,7 @@ class StrictVariableGetterBlock(BlockABC):
             :class:`~ya_tagscript.adapters.StringAdapter` documentation).
     """
 
-    @property
-    def _accepted_names(self) -> None:
-        return None
+    _VALID_NAMES = set()
 
     def will_accept(self, ctx: Context) -> bool:
         """

--- a/src/ya_tagscript/interfaces/blockabc.py
+++ b/src/ya_tagscript/interfaces/blockabc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -12,10 +13,19 @@ class BlockABC(ABC):
     Abstract base class for all block types.
 
     All blocks must inherit from this class and implement the
-    :attr:`~BlockABC._accepted_names` property and :meth:`~BlockABC.process` method.
+    :attr:`~BlockABC._VALID_NAMES` attribute and :meth:`~BlockABC.process` method.
     """
 
     # Note: Attributes have individual docstrings because the Sphinx output is prettier
+
+    _VALID_NAMES: set[str]
+    """
+    A :class:`set` of all valid block names (all lowercase).
+
+    Blocks with no defined names like variable getter blocks should return an empty set.
+
+    .. versionadded:: 1.7
+    """
 
     requires_any_parameter: bool = False
     """
@@ -57,11 +67,20 @@ class BlockABC(ABC):
     """
 
     @property
-    @abstractmethod
     def _accepted_names(self) -> set[str] | None:
         """
         A :class:`set` of all valid block names (all lowercase) or :data:`None` if no
         block names can be defined (e.g. variable getter blocks).
+
+        .. versionchanged:: 1.7
+
+           This method is no longer abstract. The default implementation matches the
+           previously described behaviour, but it returns :attr:`BlockABC._VALID_NAMES`
+           (or :data:`None` for empty sets in :attr:`BlockABC._VALID_NAMES`).
+
+        .. deprecated:: 1.7
+
+           Use :attr:`~BlockABC._VALID_NAMES` instead. This will be removed in 2.0.
 
         Returns
         -------
@@ -71,7 +90,13 @@ class BlockABC(ABC):
             May be :data:`None` if the block does not have predefined names (e.g.
             variable getter blocks).
         """
-        ...
+        warnings.warn(
+            "Deprecated since v1.7. Use _VALID_NAMES instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self._VALID_NAMES if len(self._VALID_NAMES) > 0 else None
 
     @abstractmethod
     def process(self, ctx: Context) -> str | None:
@@ -99,7 +124,7 @@ class BlockABC(ABC):
 
         1. ``name_match``: Current node's :attr:`~NodeABC.declaration` is not
            :data:`None` **and** its lowercased version appears in the block's
-           :attr:`~BlockABC._accepted_names` property.
+           :attr:`~BlockABC._VALID_NAMES` attribute.
 
         2. ``param_match``: Parameter requirements:
 
@@ -135,7 +160,7 @@ class BlockABC(ABC):
         bool
             Whether the block will accept processing of the Context
         """
-        names = self._accepted_names if self._accepted_names is not None else set()
+        names = self._VALID_NAMES
         node = ctx.node
         declaration = node.declaration
 

--- a/src/ya_tagscript/interfaces/blockabc.py
+++ b/src/ya_tagscript/interfaces/blockabc.py
@@ -160,7 +160,7 @@ class BlockABC(ABC):
         bool
             Whether the block will accept processing of the Context
         """
-        names = self._VALID_NAMES
+        names = self._accepted_names if self._accepted_names is not None else set()
         node = ctx.node
         declaration = node.declaration
 

--- a/src/ya_tagscript/interpreter/interpreter.py
+++ b/src/ya_tagscript/interpreter/interpreter.py
@@ -43,16 +43,16 @@ class TagScriptInterpreter(InterpreterABC):
         self.blocks: Sequence[BlockABC] = blocks
         self.work_limit: int | None = None
         self.total_work: int = 0
-        # fast lookup dict for blocks with non-None _accepted_names
+        # fast lookup dict for blocks with non-empty _VALID_NAMES
         self._named_blocks: dict[str, BlockABC] = {}
-        # fallback list for blocks where _accepted_names is None
+        # fallback list for blocks where _VALID_NAMES is empty
         self._unnamed_blocks: list[BlockABC] = []
 
         # register blocks in the appropriate group
         for block in blocks:
             # noinspection PyProtectedMember
-            names = block._accepted_names  # pyright: ignore [reportPrivateUsage]
-            if names is not None:
+            names = block._VALID_NAMES  # pyright: ignore [reportPrivateUsage]
+            if len(names) > 0:
                 for name in names:
                     self._named_blocks[name.lower()] = block
             else:

--- a/src/ya_tagscript/interpreter/interpreter.py
+++ b/src/ya_tagscript/interpreter/interpreter.py
@@ -43,16 +43,16 @@ class TagScriptInterpreter(InterpreterABC):
         self.blocks: Sequence[BlockABC] = blocks
         self.work_limit: int | None = None
         self.total_work: int = 0
-        # fast lookup dict for blocks with non-empty _VALID_NAMES
+        # fast lookup dict for blocks with non-None _accepted_names
         self._named_blocks: dict[str, BlockABC] = {}
-        # fallback list for blocks where _VALID_NAMES is empty
+        # fallback list for blocks where _accepted_names is None
         self._unnamed_blocks: list[BlockABC] = []
 
         # register blocks in the appropriate group
         for block in blocks:
-            # noinspection PyProtectedMember
-            names = block._VALID_NAMES  # pyright: ignore [reportPrivateUsage]
-            if len(names) > 0:
+            # noinspection PyProtectedMember,PyDeprecation
+            names = block._accepted_names  # pyright: ignore [reportPrivateUsage]
+            if names is not None:
                 for name in names:
                     self._named_blocks[name.lower()] = block
             else:

--- a/tests/ya_tagscript/blocks/actions/test_command_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_command_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CommandBlock()
     assert block._accepted_names == {"c", "com", "cmd", "command"}

--- a/tests/ya_tagscript/blocks/actions/test_command_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_command_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CommandBlock()
     assert block._accepted_names == {"c", "com", "cmd", "command"}
+
+
+def test_valid_names():
+    block = blocks.CommandBlock()
+    assert block._VALID_NAMES == {"c", "com", "cmd", "command"}
 
 
 @pytest.mark.parametrize(

--- a/tests/ya_tagscript/blocks/actions/test_delete_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_delete_block.py
@@ -14,9 +14,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.DeleteBlock()
     assert block._accepted_names == {"del", "delete"}
+
+
+def test_valid_names():
+    block = blocks.DeleteBlock()
+    assert block._VALID_NAMES == {"del", "delete"}
 
 
 def test_dec_delete_duplicated_uses_dont_matter(

--- a/tests/ya_tagscript/blocks/actions/test_delete_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_delete_block.py
@@ -14,7 +14,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.DeleteBlock()
     assert block._accepted_names == {"del", "delete"}

--- a/tests/ya_tagscript/blocks/actions/test_override_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_override_block.py
@@ -13,7 +13,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.OverrideBlock()
     assert block._accepted_names == {"override"}

--- a/tests/ya_tagscript/blocks/actions/test_override_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_override_block.py
@@ -13,9 +13,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.OverrideBlock()
     assert block._accepted_names == {"override"}
+
+
+def test_valid_names():
+    block = blocks.OverrideBlock()
+    assert block._VALID_NAMES == {"override"}
 
 
 @pytest.mark.parametrize(

--- a/tests/ya_tagscript/blocks/actions/test_react_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_react_block.py
@@ -16,9 +16,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.ReactBlock()
     assert block._accepted_names == {"react", "reactu"}
+
+
+def test_valid_names():
+    block = blocks.ReactBlock()
+    assert block._VALID_NAMES == {"react", "reactu"}
 
 
 @pytest.mark.parametrize(

--- a/tests/ya_tagscript/blocks/actions/test_react_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_react_block.py
@@ -16,7 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.ReactBlock()
     assert block._accepted_names == {"react", "reactu"}

--- a/tests/ya_tagscript/blocks/actions/test_redirect_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_redirect_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RedirectBlock()
     assert block._accepted_names == {"redirect"}

--- a/tests/ya_tagscript/blocks/actions/test_redirect_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_redirect_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RedirectBlock()
     assert block._accepted_names == {"redirect"}
+
+
+def test_valid_names():
+    block = blocks.RedirectBlock()
+    assert block._VALID_NAMES == {"redirect"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/actions/test_silence_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_silence_block.py
@@ -12,7 +12,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.SilenceBlock()
     assert block._accepted_names == {"silence", "silent"}

--- a/tests/ya_tagscript/blocks/actions/test_silence_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_silence_block.py
@@ -12,9 +12,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.SilenceBlock()
     assert block._accepted_names == {"silence", "silent"}
+
+
+def test_valid_names():
+    block = blocks.SilenceBlock()
+    assert block._VALID_NAMES == {"silence", "silent"}
 
 
 def test_dec_silence_sets_silence_action(

--- a/tests/ya_tagscript/blocks/conditional/test_all_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_all_block.py
@@ -17,9 +17,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.AllBlock()
     assert block._accepted_names == {"all", "and"}
+
+
+def test_valid_names():
+    block = blocks.AllBlock()
+    assert block._VALID_NAMES == {"all", "and"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/conditional/test_all_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_all_block.py
@@ -17,7 +17,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.AllBlock()
     assert block._accepted_names == {"all", "and"}

--- a/tests/ya_tagscript/blocks/conditional/test_any_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_any_block.py
@@ -17,9 +17,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.AnyBlock()
     assert block._accepted_names == {"any", "or"}
+
+
+def test_valid_names():
+    block = blocks.AnyBlock()
+    assert block._VALID_NAMES == {"any", "or"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/conditional/test_any_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_any_block.py
@@ -17,7 +17,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.AnyBlock()
     assert block._accepted_names == {"any", "or"}

--- a/tests/ya_tagscript/blocks/conditional/test_if_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_if_block.py
@@ -17,7 +17,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.IfBlock()
     assert block._accepted_names == {"if"}

--- a/tests/ya_tagscript/blocks/conditional/test_if_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_if_block.py
@@ -17,9 +17,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.IfBlock()
     assert block._accepted_names == {"if"}
+
+
+def test_valid_names():
+    block = blocks.IfBlock()
+    assert block._VALID_NAMES == {"if"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/discord/test_cooldown_block.py
+++ b/tests/ya_tagscript/blocks/discord/test_cooldown_block.py
@@ -30,9 +30,15 @@ def mock_cm():
         yield mocked_cm
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CooldownBlock()
     assert block._accepted_names == {"cooldown"}
+
+
+def test_valid_names():
+    block = blocks.CooldownBlock()
+    assert block._VALID_NAMES == {"cooldown"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/discord/test_cooldown_block.py
+++ b/tests/ya_tagscript/blocks/discord/test_cooldown_block.py
@@ -30,7 +30,6 @@ def mock_cm():
         yield mocked_cm
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CooldownBlock()
     assert block._accepted_names == {"cooldown"}

--- a/tests/ya_tagscript/blocks/discord/test_embed_block.py
+++ b/tests/ya_tagscript/blocks/discord/test_embed_block.py
@@ -19,9 +19,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.EmbedBlock()
     assert block._accepted_names == {"embed"}
+
+
+def test_valid_names():
+    block = blocks.EmbedBlock()
+    assert block._VALID_NAMES == {"embed"}
 
 
 def test_process_method_accepts_missing_parameter():

--- a/tests/ya_tagscript/blocks/discord/test_embed_block.py
+++ b/tests/ya_tagscript/blocks/discord/test_embed_block.py
@@ -19,7 +19,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.EmbedBlock()
     assert block._accepted_names == {"embed"}

--- a/tests/ya_tagscript/blocks/flow/test_break_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_break_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.BreakBlock()
     assert block._accepted_names == {"break", "shortcircuit", "short"}

--- a/tests/ya_tagscript/blocks/flow/test_break_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_break_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.BreakBlock()
     assert block._accepted_names == {"break", "shortcircuit", "short"}
+
+
+def test_valid_names():
+    block = blocks.BreakBlock()
+    assert block._VALID_NAMES == {"break", "shortcircuit", "short"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/flow/test_shortcutredirect_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_shortcutredirect_block.py
@@ -15,10 +15,16 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     # returns None intentionally
     block = blocks.ShortcutRedirectBlock("test")
     assert block._accepted_names is None
+
+
+def test_valid_names():
+    block = blocks.ShortcutRedirectBlock("test")
+    assert block._VALID_NAMES == set()
 
 
 def test_will_accept_rejects_missing_declaration():

--- a/tests/ya_tagscript/blocks/flow/test_shortcutredirect_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_shortcutredirect_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     # returns None intentionally
     block = blocks.ShortcutRedirectBlock("test")

--- a/tests/ya_tagscript/blocks/flow/test_stop_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_stop_block.py
@@ -27,7 +27,6 @@ def ts_interpreter_with_all_block():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.StopBlock()
     assert block._accepted_names == {"stop", "halt", "error"}

--- a/tests/ya_tagscript/blocks/flow/test_stop_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_stop_block.py
@@ -27,9 +27,15 @@ def ts_interpreter_with_all_block():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.StopBlock()
     assert block._accepted_names == {"stop", "halt", "error"}
+
+
+def test_valid_names():
+    block = blocks.StopBlock()
+    assert block._VALID_NAMES == {"stop", "halt", "error"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/limiters/test_blacklist_block.py
+++ b/tests/ya_tagscript/blocks/limiters/test_blacklist_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.BlacklistBlock()
     assert block._accepted_names == {"blacklist"}

--- a/tests/ya_tagscript/blocks/limiters/test_blacklist_block.py
+++ b/tests/ya_tagscript/blocks/limiters/test_blacklist_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.BlacklistBlock()
     assert block._accepted_names == {"blacklist"}
+
+
+def test_valid_names():
+    block = blocks.BlacklistBlock()
+    assert block._VALID_NAMES == {"blacklist"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/limiters/test_require_block.py
+++ b/tests/ya_tagscript/blocks/limiters/test_require_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RequireBlock()
     assert block._accepted_names == {"require", "whitelist"}

--- a/tests/ya_tagscript/blocks/limiters/test_require_block.py
+++ b/tests/ya_tagscript/blocks/limiters/test_require_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RequireBlock()
     assert block._accepted_names == {"require", "whitelist"}
+
+
+def test_valid_names():
+    block = blocks.RequireBlock()
+    assert block._VALID_NAMES == {"require", "whitelist"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/lists/test_cycle_block.py
+++ b/tests/ya_tagscript/blocks/lists/test_cycle_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CycleBlock()
     assert block._accepted_names == {"cycle"}
+
+
+def test_valid_names():
+    block = blocks.CycleBlock()
+    assert block._VALID_NAMES == {"cycle"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/lists/test_cycle_block.py
+++ b/tests/ya_tagscript/blocks/lists/test_cycle_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CycleBlock()
     assert block._accepted_names == {"cycle"}

--- a/tests/ya_tagscript/blocks/lists/test_list_block.py
+++ b/tests/ya_tagscript/blocks/lists/test_list_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.ListBlock()
     assert block._accepted_names == {"list"}
+
+
+def test_valid_names():
+    block = blocks.ListBlock()
+    assert block._VALID_NAMES == {"list"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/lists/test_list_block.py
+++ b/tests/ya_tagscript/blocks/lists/test_list_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.ListBlock()
     assert block._accepted_names == {"list"}

--- a/tests/ya_tagscript/blocks/math/test_math_block.py
+++ b/tests/ya_tagscript/blocks/math/test_math_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.MathBlock()
     assert block._accepted_names == {"math", "m", "+", "calc"}
+
+
+def test_valid_names():
+    block = blocks.MathBlock()
+    assert block._VALID_NAMES == {"math", "m", "+", "calc"}
 
 
 def test_process_method_rejects_missing_payload():

--- a/tests/ya_tagscript/blocks/math/test_math_block.py
+++ b/tests/ya_tagscript/blocks/math/test_math_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.MathBlock()
     assert block._accepted_names == {"math", "m", "+", "calc"}

--- a/tests/ya_tagscript/blocks/math/test_ordinal_block.py
+++ b/tests/ya_tagscript/blocks/math/test_ordinal_block.py
@@ -78,9 +78,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.OrdinalBlock()
     assert block._accepted_names == {"o", "ord"}
+
+
+def test_valid_names():
+    block = blocks.OrdinalBlock()
+    assert block._VALID_NAMES == {"o", "ord"}
 
 
 def test_process_method_rejects_missing_payload():

--- a/tests/ya_tagscript/blocks/math/test_ordinal_block.py
+++ b/tests/ya_tagscript/blocks/math/test_ordinal_block.py
@@ -78,7 +78,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.OrdinalBlock()
     assert block._accepted_names == {"o", "ord"}

--- a/tests/ya_tagscript/blocks/meta/test_comment_block.py
+++ b/tests/ya_tagscript/blocks/meta/test_comment_block.py
@@ -23,7 +23,6 @@ def ts_interpreter_with_cmd_block():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CommentBlock()
     assert block._accepted_names == {"/", "//", "comment"}

--- a/tests/ya_tagscript/blocks/meta/test_comment_block.py
+++ b/tests/ya_tagscript/blocks/meta/test_comment_block.py
@@ -23,9 +23,15 @@ def ts_interpreter_with_cmd_block():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CommentBlock()
     assert block._accepted_names == {"/", "//", "comment"}
+
+
+def test_valid_names():
+    block = blocks.CommentBlock()
+    assert block._VALID_NAMES == {"/", "//", "comment"}
 
 
 def test_process_method_does_not_touch_ctx():

--- a/tests/ya_tagscript/blocks/meta/test_debug_block.py
+++ b/tests/ya_tagscript/blocks/meta/test_debug_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.DebugBlock()
     assert block._accepted_names == {"debug"}
+
+
+def test_valid_names():
+    block = blocks.DebugBlock()
+    assert block._VALID_NAMES == {"debug"}
 
 
 def test_dec_debug_docs_example_one(

--- a/tests/ya_tagscript/blocks/meta/test_debug_block.py
+++ b/tests/ya_tagscript/blocks/meta/test_debug_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.DebugBlock()
     assert block._accepted_names == {"debug"}

--- a/tests/ya_tagscript/blocks/rng/test_fiftyfifty_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_fiftyfifty_block.py
@@ -16,9 +16,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.FiftyFiftyBlock()
     assert block._accepted_names == {"5050", "50", "?"}
+
+
+def test_valid_names():
+    block = blocks.FiftyFiftyBlock()
+    assert block._VALID_NAMES == {"5050", "50", "?"}
 
 
 def test_process_method_rejects_missing_payload():

--- a/tests/ya_tagscript/blocks/rng/test_fiftyfifty_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_fiftyfifty_block.py
@@ -16,7 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.FiftyFiftyBlock()
     assert block._accepted_names == {"5050", "50", "?"}

--- a/tests/ya_tagscript/blocks/rng/test_random_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_random_block.py
@@ -16,7 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RandomBlock()
     assert block._accepted_names == {"random", "rand", "#"}

--- a/tests/ya_tagscript/blocks/rng/test_random_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_random_block.py
@@ -16,9 +16,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RandomBlock()
     assert block._accepted_names == {"random", "rand", "#"}
+
+
+def test_valid_names():
+    block = blocks.RandomBlock()
+    assert block._VALID_NAMES == {"random", "rand", "#"}
 
 
 def test_process_method_rejects_missing_payload():

--- a/tests/ya_tagscript/blocks/rng/test_range_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_range_block.py
@@ -75,7 +75,6 @@ def test_process_method_rejects_whitespace_only_payload():
     assert returned is None
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RangeBlock()
     assert block._accepted_names == {"range", "rangef"}

--- a/tests/ya_tagscript/blocks/rng/test_range_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_range_block.py
@@ -75,9 +75,15 @@ def test_process_method_rejects_whitespace_only_payload():
     assert returned is None
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.RangeBlock()
     assert block._accepted_names == {"range", "rangef"}
+
+
+def test_valid_names():
+    block = blocks.RangeBlock()
+    assert block._VALID_NAMES == {"range", "rangef"}
 
 
 def test_dec_range_docs_example_one(

--- a/tests/ya_tagscript/blocks/strings/test_case_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_case_block.py
@@ -16,7 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CaseBlock()
     assert block._accepted_names == {"upper", "lower"}

--- a/tests/ya_tagscript/blocks/strings/test_case_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_case_block.py
@@ -16,9 +16,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.CaseBlock()
     assert block._accepted_names == {"upper", "lower"}
+
+
+def test_valid_names():
+    block = blocks.CaseBlock()
+    assert block._VALID_NAMES == {"upper", "lower"}
 
 
 def test_process_method_rejects_missing_declaration():

--- a/tests/ya_tagscript/blocks/strings/test_join_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_join_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.JoinBlock()
     assert block._accepted_names == {"join"}
+
+
+def test_valid_names():
+    block = blocks.JoinBlock()
+    assert block._VALID_NAMES == {"join"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/strings/test_join_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_join_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.JoinBlock()
     assert block._accepted_names == {"join"}

--- a/tests/ya_tagscript/blocks/strings/test_python_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_python_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.PythonBlock()
     assert block._accepted_names == {"contains", "in", "index"}

--- a/tests/ya_tagscript/blocks/strings/test_python_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_python_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.PythonBlock()
     assert block._accepted_names == {"contains", "in", "index"}
+
+
+def test_valid_names():
+    block = blocks.PythonBlock()
+    assert block._VALID_NAMES == {"contains", "in", "index"}
 
 
 def test_process_method_rejects_missing_declaration():

--- a/tests/ya_tagscript/blocks/strings/test_replace_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_replace_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.ReplaceBlock()
     assert block._accepted_names == {"replace"}

--- a/tests/ya_tagscript/blocks/strings/test_replace_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_replace_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.ReplaceBlock()
     assert block._accepted_names == {"replace"}
+
+
+def test_valid_names():
+    block = blocks.ReplaceBlock()
+    assert block._VALID_NAMES == {"replace"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/strings/test_substring_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_substring_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.SubstringBlock()
     assert block._accepted_names == {"substring", "substr"}
+
+
+def test_valid_names():
+    block = blocks.SubstringBlock()
+    assert block._VALID_NAMES == {"substring", "substr"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/strings/test_substring_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_substring_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.SubstringBlock()
     assert block._accepted_names == {"substring", "substr"}

--- a/tests/ya_tagscript/blocks/strings/test_urldecode_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_urldecode_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.URLDecodeBlock()
     assert block._accepted_names == {"urldecode"}

--- a/tests/ya_tagscript/blocks/strings/test_urldecode_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_urldecode_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.URLDecodeBlock()
     assert block._accepted_names == {"urldecode"}
+
+
+def test_valid_names():
+    block = blocks.URLDecodeBlock()
+    assert block._VALID_NAMES == {"urldecode"}
 
 
 def test_process_method_rejects_missing_payload():

--- a/tests/ya_tagscript/blocks/strings/test_urlencode_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_urlencode_block.py
@@ -15,9 +15,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.URLEncodeBlock()
     assert block._accepted_names == {"urlencode"}
+
+
+def test_valid_names():
+    block = blocks.URLEncodeBlock()
+    assert block._VALID_NAMES == {"urlencode"}
 
 
 def test_process_method_rejects_missing_payload():

--- a/tests/ya_tagscript/blocks/strings/test_urlencode_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_urlencode_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.URLEncodeBlock()
     assert block._accepted_names == {"urlencode"}

--- a/tests/ya_tagscript/blocks/time/test_strf_block.py
+++ b/tests/ya_tagscript/blocks/time/test_strf_block.py
@@ -27,7 +27,6 @@ def mock_dt():
         yield mocked_dt
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.StrfBlock()
     assert block._accepted_names == {"strf", "unix"}

--- a/tests/ya_tagscript/blocks/time/test_strf_block.py
+++ b/tests/ya_tagscript/blocks/time/test_strf_block.py
@@ -27,9 +27,15 @@ def mock_dt():
         yield mocked_dt
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.StrfBlock()
     assert block._accepted_names == {"strf", "unix"}
+
+
+def test_valid_names():
+    block = blocks.StrfBlock()
+    assert block._VALID_NAMES == {"strf", "unix"}
 
 
 def test_process_method_rejects_missing_declaration():

--- a/tests/ya_tagscript/blocks/time/test_timedelta_block.py
+++ b/tests/ya_tagscript/blocks/time/test_timedelta_block.py
@@ -65,9 +65,15 @@ def ts_interpreter_with_custom_humanize_fn_in_td_block(
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.TimedeltaBlock()
     assert block._accepted_names == {"timedelta", "td"}
+
+
+def test_valid_names():
+    block = blocks.TimedeltaBlock()
+    assert block._VALID_NAMES == {"timedelta", "td"}
 
 
 def test_process_method_rejects_missing_payload():

--- a/tests/ya_tagscript/blocks/time/test_timedelta_block.py
+++ b/tests/ya_tagscript/blocks/time/test_timedelta_block.py
@@ -65,7 +65,6 @@ def ts_interpreter_with_custom_humanize_fn_in_td_block(
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.TimedeltaBlock()
     assert block._accepted_names == {"timedelta", "td"}

--- a/tests/ya_tagscript/blocks/variables/test_assign_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_assign_block.py
@@ -16,7 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.AssignmentBlock()
     assert block._accepted_names == {"=", "assign", "let", "var"}

--- a/tests/ya_tagscript/blocks/variables/test_assign_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_assign_block.py
@@ -16,9 +16,15 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.AssignmentBlock()
     assert block._accepted_names == {"=", "assign", "let", "var"}
+
+
+def test_valid_names():
+    block = blocks.AssignmentBlock()
+    assert block._VALID_NAMES == {"=", "assign", "let", "var"}
 
 
 def test_process_method_rejects_missing_parameter():

--- a/tests/ya_tagscript/blocks/variables/test_loose_variable_getter_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_loose_variable_getter_block.py
@@ -15,10 +15,16 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.LooseVariableGetterBlock()
     # returns None intentionally
     assert block._accepted_names is None
+
+
+def test_valid_names():
+    block = blocks.LooseVariableGetterBlock()
+    assert block._VALID_NAMES == set()
 
 
 def test_will_accept_is_always_true():

--- a/tests/ya_tagscript/blocks/variables/test_loose_variable_getter_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_loose_variable_getter_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.LooseVariableGetterBlock()
     # returns None intentionally

--- a/tests/ya_tagscript/blocks/variables/test_strict_variable_getter_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_strict_variable_getter_block.py
@@ -15,10 +15,16 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
+@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.StrictVariableGetterBlock()
     # returns None intentionally
     assert block._accepted_names is None
+
+
+def test_valid_names():
+    block = blocks.StrictVariableGetterBlock()
+    assert block._VALID_NAMES == set()
 
 
 def test_will_accept_rejects_missing_declaration():

--- a/tests/ya_tagscript/blocks/variables/test_strict_variable_getter_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_strict_variable_getter_block.py
@@ -15,7 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-@pytest.mark.filterwarnings("ignore:Deprecated since v1.7. Use _VALID_NAMES instead")
 def test_accepted_names():
     block = blocks.StrictVariableGetterBlock()
     # returns None intentionally


### PR DESCRIPTION
> [!IMPORTANT]
> This is an important **change** for any custom blocks. `_accepted_names` will be kept for compatibility, but it is deprecated and scheduled for removal in v2. It will only return the value of `_VALID_NAMES` or `None` if `_VALID_NAMES` is an empty set.

The `_accepted_names` property created a new set for each call. Since the set contents never changed, this was pretty wasteful.

The new `_VALID_NAMES` attribute is always a `set[str]`, even when the block itself cannot define a set of valid names (e.g. variable getter blocks). In those cases, the block must define an empty set.