### PR TITLE
Limit workflow runs to pushes on v1 branch

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,12 @@
 name: Lint
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - v1
+
+  pull_request:
+
 
 jobs:
   lint:

--- a/.github/workflows/coverage_comment.yml
+++ b/.github/workflows/coverage_comment.yml
@@ -4,6 +4,8 @@ on:
     workflows: [ 'Test' ]
     types:
       - completed
+    branches:
+      - '!v1'
 
 jobs:
   post-coverage-comment:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,10 @@
 name: Build & Publish to PyPI
 
-on: push
+on:
+  push:
+    branches:
+      - v1
+
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - v1
+
+  pull_request:
+
 
 jobs:
   test:


### PR DESCRIPTION
Currently, all PR pushes run tests for `push` and also `pull_request` events which is very stupid.

The `build` workflow doesn't need to run on PRs at all.
The `coverage_comment` workflow makes no sense to run on the `v1` main branch.