### PR TITLE
Remove deprecated _accepted_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Unreleased
 
-*Currently none*
+- Breaking: Remove `_accepted_names` in favour of `_VALID_NAMES`
+    - Migrate by declaring the block names current in the `_accepted_names` property to
+      a class-level `_VALID_NAMES` declaration:
+
+          class MyBlock(BlockABC):
+
+              # new:
+              _VALID_NAMES = {"my-dec", "some-alias"}
+
+              # remove:
+              @property
+              def _accepted_names(self) -> set[str] | None:
+                  return {"my-dec", "some-alias"}
+
+    - Make sure any custom handling in `will_accept` or `process` takes this change into
+      account.
 
 # v1.7.2 (2026-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,17 @@
 # Unreleased
 
-- Breaking: Remove `_accepted_names` in favour of `_VALID_NAMES`
+- BREAKING: Remove `_accepted_names` in favour of `_VALID_NAMES`
     - Migrate by declaring the block names current in the `_accepted_names` property to
       a class-level `_VALID_NAMES` declaration:
 
-          class MyBlock(BlockABC):
+        ```diff
+        class MyBlock(BlockABC):
+        +    _VALID_NAMES = {"my-dec", "some-alias"}
 
-              # new:
-              _VALID_NAMES = {"my-dec", "some-alias"}
-
-              # remove:
-              @property
-              def _accepted_names(self) -> set[str] | None:
-                  return {"my-dec", "some-alias"}
+        -    @property
+        -    def _accepted_names(self) -> set[str] | None:
+        -        return {"my-dec", "some-alias"}
+        ```
 
     - Make sure any custom handling in `will_accept` or `process` takes this change into
       account.

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -20,7 +20,7 @@ For example, the concrete :class:`~ya_tagscript.interpreter.TagScriptInterpreter
 
 .. autoclass:: BlockABC
     :members:
-    :private-members: _accepted_names, _VALID_NAMES
+    :private-members: _VALID_NAMES
     :no-show-inheritance:
 
 .. autoclass:: InterpreterABC

--- a/src/ya_tagscript/blocks/rng/range_block.py
+++ b/src/ya_tagscript/blocks/rng/range_block.py
@@ -51,11 +51,7 @@ class RangeBlock(BlockABC):
 
     def process(self, ctx: Context) -> str | None:
         declaration = ctx.node.declaration
-        # go via _accepted_names to preserve compatibility during the deprecation
-        valid_names = (
-            self._accepted_names if self._accepted_names is not None else set()
-        )
-        if declaration is None or declaration not in valid_names:
+        if declaration is None or declaration not in self._VALID_NAMES:
             return None
 
         payload = ctx.node.payload

--- a/src/ya_tagscript/interfaces/blockabc.py
+++ b/src/ya_tagscript/interfaces/blockabc.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -66,38 +65,6 @@ class BlockABC(ABC):
         Subclasses must override this if they require this restriction.
     """
 
-    @property
-    def _accepted_names(self) -> set[str] | None:
-        """
-        A :class:`set` of all valid block names (all lowercase) or :data:`None` if no
-        block names can be defined (e.g. variable getter blocks).
-
-        .. versionchanged:: 1.7
-
-           This method is no longer abstract. The default implementation matches the
-           previously described behaviour, but it returns :attr:`BlockABC._VALID_NAMES`
-           (or :data:`None` for empty sets in :attr:`BlockABC._VALID_NAMES`).
-
-        .. deprecated:: 1.7
-
-           Use :attr:`~BlockABC._VALID_NAMES` instead. This will be removed in 2.0.
-
-        Returns
-        -------
-        set[str] | None
-            A set of lowercase strings representing possible acceptable block
-            declarations that can be handled by this block.
-            May be :data:`None` if the block does not have predefined names (e.g.
-            variable getter blocks).
-        """
-        warnings.warn(
-            "Deprecated since v1.7. Use _VALID_NAMES instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return self._VALID_NAMES if len(self._VALID_NAMES) > 0 else None
-
     @abstractmethod
     def process(self, ctx: Context) -> str | None:
         """
@@ -160,11 +127,12 @@ class BlockABC(ABC):
         bool
             Whether the block will accept processing of the Context
         """
-        names = self._accepted_names if self._accepted_names is not None else set()
         node = ctx.node
         declaration = node.declaration
 
-        name_match = (declaration is not None) and (declaration.lower() in names)
+        name_match = (declaration is not None) and (
+            declaration.lower() in self._VALID_NAMES
+        )
         param_match = True
         payload_match = True
         if self.requires_any_parameter:

--- a/src/ya_tagscript/interpreter/interpreter.py
+++ b/src/ya_tagscript/interpreter/interpreter.py
@@ -43,16 +43,16 @@ class TagScriptInterpreter(InterpreterABC):
         self.blocks: Sequence[BlockABC] = blocks
         self.work_limit: int | None = None
         self.total_work: int = 0
-        # fast lookup dict for blocks with non-None _accepted_names
+        # fast lookup dict for blocks with non-empty _VALID_NAMES
         self._named_blocks: dict[str, BlockABC] = {}
-        # fallback list for blocks where _accepted_names is None
+        # fallback list for blocks where _VALID_NAMES is empty
         self._unnamed_blocks: list[BlockABC] = []
 
         # register blocks in the appropriate group
         for block in blocks:
-            # noinspection PyProtectedMember,PyDeprecation
-            names = block._accepted_names  # pyright: ignore [reportPrivateUsage]
-            if names is not None:
+            # noinspection PyProtectedMember
+            names = block._VALID_NAMES  # pyright: ignore [reportPrivateUsage]
+            if len(names) > 0:
                 for name in names:
                     self._named_blocks[name.lower()] = block
             else:

--- a/tests/ya_tagscript/blocks/actions/test_command_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_command_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.CommandBlock()
-    assert block._accepted_names == {"c", "com", "cmd", "command"}
-
-
 def test_valid_names():
     block = blocks.CommandBlock()
     assert block._VALID_NAMES == {"c", "com", "cmd", "command"}

--- a/tests/ya_tagscript/blocks/actions/test_delete_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_delete_block.py
@@ -14,11 +14,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.DeleteBlock()
-    assert block._accepted_names == {"del", "delete"}
-
-
 def test_valid_names():
     block = blocks.DeleteBlock()
     assert block._VALID_NAMES == {"del", "delete"}

--- a/tests/ya_tagscript/blocks/actions/test_override_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_override_block.py
@@ -13,11 +13,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.OverrideBlock()
-    assert block._accepted_names == {"override"}
-
-
 def test_valid_names():
     block = blocks.OverrideBlock()
     assert block._VALID_NAMES == {"override"}

--- a/tests/ya_tagscript/blocks/actions/test_react_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_react_block.py
@@ -16,11 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.ReactBlock()
-    assert block._accepted_names == {"react", "reactu"}
-
-
 def test_valid_names():
     block = blocks.ReactBlock()
     assert block._VALID_NAMES == {"react", "reactu"}

--- a/tests/ya_tagscript/blocks/actions/test_redirect_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_redirect_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.RedirectBlock()
-    assert block._accepted_names == {"redirect"}
-
-
 def test_valid_names():
     block = blocks.RedirectBlock()
     assert block._VALID_NAMES == {"redirect"}

--- a/tests/ya_tagscript/blocks/actions/test_silence_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_silence_block.py
@@ -12,11 +12,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.SilenceBlock()
-    assert block._accepted_names == {"silence", "silent"}
-
-
 def test_valid_names():
     block = blocks.SilenceBlock()
     assert block._VALID_NAMES == {"silence", "silent"}

--- a/tests/ya_tagscript/blocks/conditional/test_all_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_all_block.py
@@ -17,11 +17,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.AllBlock()
-    assert block._accepted_names == {"all", "and"}
-
-
 def test_valid_names():
     block = blocks.AllBlock()
     assert block._VALID_NAMES == {"all", "and"}

--- a/tests/ya_tagscript/blocks/conditional/test_any_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_any_block.py
@@ -17,11 +17,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.AnyBlock()
-    assert block._accepted_names == {"any", "or"}
-
-
 def test_valid_names():
     block = blocks.AnyBlock()
     assert block._VALID_NAMES == {"any", "or"}

--- a/tests/ya_tagscript/blocks/conditional/test_if_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_if_block.py
@@ -17,11 +17,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.IfBlock()
-    assert block._accepted_names == {"if"}
-
-
 def test_valid_names():
     block = blocks.IfBlock()
     assert block._VALID_NAMES == {"if"}

--- a/tests/ya_tagscript/blocks/discord/test_cooldown_block.py
+++ b/tests/ya_tagscript/blocks/discord/test_cooldown_block.py
@@ -30,11 +30,6 @@ def mock_cm():
         yield mocked_cm
 
 
-def test_accepted_names():
-    block = blocks.CooldownBlock()
-    assert block._accepted_names == {"cooldown"}
-
-
 def test_valid_names():
     block = blocks.CooldownBlock()
     assert block._VALID_NAMES == {"cooldown"}

--- a/tests/ya_tagscript/blocks/discord/test_embed_block.py
+++ b/tests/ya_tagscript/blocks/discord/test_embed_block.py
@@ -19,11 +19,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.EmbedBlock()
-    assert block._accepted_names == {"embed"}
-
-
 def test_valid_names():
     block = blocks.EmbedBlock()
     assert block._VALID_NAMES == {"embed"}

--- a/tests/ya_tagscript/blocks/flow/test_break_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_break_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.BreakBlock()
-    assert block._accepted_names == {"break", "shortcircuit", "short"}
-
-
 def test_valid_names():
     block = blocks.BreakBlock()
     assert block._VALID_NAMES == {"break", "shortcircuit", "short"}

--- a/tests/ya_tagscript/blocks/flow/test_shortcutredirect_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_shortcutredirect_block.py
@@ -15,12 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    # returns None intentionally
-    block = blocks.ShortcutRedirectBlock("test")
-    assert block._accepted_names is None
-
-
 def test_valid_names():
     block = blocks.ShortcutRedirectBlock("test")
     assert block._VALID_NAMES == set()

--- a/tests/ya_tagscript/blocks/flow/test_stop_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_stop_block.py
@@ -27,11 +27,6 @@ def ts_interpreter_with_all_block():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.StopBlock()
-    assert block._accepted_names == {"stop", "halt", "error"}
-
-
 def test_valid_names():
     block = blocks.StopBlock()
     assert block._VALID_NAMES == {"stop", "halt", "error"}

--- a/tests/ya_tagscript/blocks/limiters/test_blacklist_block.py
+++ b/tests/ya_tagscript/blocks/limiters/test_blacklist_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.BlacklistBlock()
-    assert block._accepted_names == {"blacklist"}
-
-
 def test_valid_names():
     block = blocks.BlacklistBlock()
     assert block._VALID_NAMES == {"blacklist"}

--- a/tests/ya_tagscript/blocks/limiters/test_require_block.py
+++ b/tests/ya_tagscript/blocks/limiters/test_require_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.RequireBlock()
-    assert block._accepted_names == {"require", "whitelist"}
-
-
 def test_valid_names():
     block = blocks.RequireBlock()
     assert block._VALID_NAMES == {"require", "whitelist"}

--- a/tests/ya_tagscript/blocks/lists/test_cycle_block.py
+++ b/tests/ya_tagscript/blocks/lists/test_cycle_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.CycleBlock()
-    assert block._accepted_names == {"cycle"}
-
-
 def test_valid_names():
     block = blocks.CycleBlock()
     assert block._VALID_NAMES == {"cycle"}

--- a/tests/ya_tagscript/blocks/lists/test_list_block.py
+++ b/tests/ya_tagscript/blocks/lists/test_list_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.ListBlock()
-    assert block._accepted_names == {"list"}
-
-
 def test_valid_names():
     block = blocks.ListBlock()
     assert block._VALID_NAMES == {"list"}

--- a/tests/ya_tagscript/blocks/math/test_math_block.py
+++ b/tests/ya_tagscript/blocks/math/test_math_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.MathBlock()
-    assert block._accepted_names == {"math", "m", "+", "calc"}
-
-
 def test_valid_names():
     block = blocks.MathBlock()
     assert block._VALID_NAMES == {"math", "m", "+", "calc"}

--- a/tests/ya_tagscript/blocks/math/test_ordinal_block.py
+++ b/tests/ya_tagscript/blocks/math/test_ordinal_block.py
@@ -78,11 +78,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.OrdinalBlock()
-    assert block._accepted_names == {"o", "ord"}
-
-
 def test_valid_names():
     block = blocks.OrdinalBlock()
     assert block._VALID_NAMES == {"o", "ord"}

--- a/tests/ya_tagscript/blocks/meta/test_comment_block.py
+++ b/tests/ya_tagscript/blocks/meta/test_comment_block.py
@@ -23,11 +23,6 @@ def ts_interpreter_with_cmd_block():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.CommentBlock()
-    assert block._accepted_names == {"/", "//", "comment"}
-
-
 def test_valid_names():
     block = blocks.CommentBlock()
     assert block._VALID_NAMES == {"/", "//", "comment"}

--- a/tests/ya_tagscript/blocks/meta/test_debug_block.py
+++ b/tests/ya_tagscript/blocks/meta/test_debug_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.DebugBlock()
-    assert block._accepted_names == {"debug"}
-
-
 def test_valid_names():
     block = blocks.DebugBlock()
     assert block._VALID_NAMES == {"debug"}

--- a/tests/ya_tagscript/blocks/rng/test_fiftyfifty_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_fiftyfifty_block.py
@@ -16,11 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.FiftyFiftyBlock()
-    assert block._accepted_names == {"5050", "50", "?"}
-
-
 def test_valid_names():
     block = blocks.FiftyFiftyBlock()
     assert block._VALID_NAMES == {"5050", "50", "?"}

--- a/tests/ya_tagscript/blocks/rng/test_random_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_random_block.py
@@ -16,11 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.RandomBlock()
-    assert block._accepted_names == {"random", "rand", "#"}
-
-
 def test_valid_names():
     block = blocks.RandomBlock()
     assert block._VALID_NAMES == {"random", "rand", "#"}

--- a/tests/ya_tagscript/blocks/rng/test_range_block.py
+++ b/tests/ya_tagscript/blocks/rng/test_range_block.py
@@ -75,11 +75,6 @@ def test_process_method_rejects_whitespace_only_payload():
     assert returned is None
 
 
-def test_accepted_names():
-    block = blocks.RangeBlock()
-    assert block._accepted_names == {"range", "rangef"}
-
-
 def test_valid_names():
     block = blocks.RangeBlock()
     assert block._VALID_NAMES == {"range", "rangef"}

--- a/tests/ya_tagscript/blocks/strings/test_case_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_case_block.py
@@ -16,11 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.CaseBlock()
-    assert block._accepted_names == {"upper", "lower"}
-
-
 def test_valid_names():
     block = blocks.CaseBlock()
     assert block._VALID_NAMES == {"upper", "lower"}

--- a/tests/ya_tagscript/blocks/strings/test_join_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_join_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.JoinBlock()
-    assert block._accepted_names == {"join"}
-
-
 def test_valid_names():
     block = blocks.JoinBlock()
     assert block._VALID_NAMES == {"join"}

--- a/tests/ya_tagscript/blocks/strings/test_python_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_python_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.PythonBlock()
-    assert block._accepted_names == {"contains", "in", "index"}
-
-
 def test_valid_names():
     block = blocks.PythonBlock()
     assert block._VALID_NAMES == {"contains", "in", "index"}

--- a/tests/ya_tagscript/blocks/strings/test_replace_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_replace_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.ReplaceBlock()
-    assert block._accepted_names == {"replace"}
-
-
 def test_valid_names():
     block = blocks.ReplaceBlock()
     assert block._VALID_NAMES == {"replace"}

--- a/tests/ya_tagscript/blocks/strings/test_substring_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_substring_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.SubstringBlock()
-    assert block._accepted_names == {"substring", "substr"}
-
-
 def test_valid_names():
     block = blocks.SubstringBlock()
     assert block._VALID_NAMES == {"substring", "substr"}

--- a/tests/ya_tagscript/blocks/strings/test_urldecode_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_urldecode_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.URLDecodeBlock()
-    assert block._accepted_names == {"urldecode"}
-
-
 def test_valid_names():
     block = blocks.URLDecodeBlock()
     assert block._VALID_NAMES == {"urldecode"}

--- a/tests/ya_tagscript/blocks/strings/test_urlencode_block.py
+++ b/tests/ya_tagscript/blocks/strings/test_urlencode_block.py
@@ -15,11 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.URLEncodeBlock()
-    assert block._accepted_names == {"urlencode"}
-
-
 def test_valid_names():
     block = blocks.URLEncodeBlock()
     assert block._VALID_NAMES == {"urlencode"}

--- a/tests/ya_tagscript/blocks/time/test_strf_block.py
+++ b/tests/ya_tagscript/blocks/time/test_strf_block.py
@@ -27,11 +27,6 @@ def mock_dt():
         yield mocked_dt
 
 
-def test_accepted_names():
-    block = blocks.StrfBlock()
-    assert block._accepted_names == {"strf", "unix"}
-
-
 def test_valid_names():
     block = blocks.StrfBlock()
     assert block._VALID_NAMES == {"strf", "unix"}

--- a/tests/ya_tagscript/blocks/time/test_timedelta_block.py
+++ b/tests/ya_tagscript/blocks/time/test_timedelta_block.py
@@ -65,11 +65,6 @@ def ts_interpreter_with_custom_humanize_fn_in_td_block(
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.TimedeltaBlock()
-    assert block._accepted_names == {"timedelta", "td"}
-
-
 def test_valid_names():
     block = blocks.TimedeltaBlock()
     assert block._VALID_NAMES == {"timedelta", "td"}

--- a/tests/ya_tagscript/blocks/variables/test_assign_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_assign_block.py
@@ -16,11 +16,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.AssignmentBlock()
-    assert block._accepted_names == {"=", "assign", "let", "var"}
-
-
 def test_valid_names():
     block = blocks.AssignmentBlock()
     assert block._VALID_NAMES == {"=", "assign", "let", "var"}

--- a/tests/ya_tagscript/blocks/variables/test_loose_variable_getter_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_loose_variable_getter_block.py
@@ -15,12 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.LooseVariableGetterBlock()
-    # returns None intentionally
-    assert block._accepted_names is None
-
-
 def test_valid_names():
     block = blocks.LooseVariableGetterBlock()
     assert block._VALID_NAMES == set()

--- a/tests/ya_tagscript/blocks/variables/test_strict_variable_getter_block.py
+++ b/tests/ya_tagscript/blocks/variables/test_strict_variable_getter_block.py
@@ -15,12 +15,6 @@ def ts_interpreter():
     return TagScriptInterpreter(b)
 
 
-def test_accepted_names():
-    block = blocks.StrictVariableGetterBlock()
-    # returns None intentionally
-    assert block._accepted_names is None
-
-
 def test_valid_names():
     block = blocks.StrictVariableGetterBlock()
     assert block._VALID_NAMES == set()


### PR DESCRIPTION
This is the removal of the `_accepted_names` property as deprecated in [v1.7.0](https://github.com/MajorTanya/ya_tagscript/releases/tag/v1.7.0).

Some profiling because I thought it'd be neat to look at how impactful the calls to `warnings.warn` are:

- Removed 352,012 calls to `_accepted_names` & `warnings.warn` (0.745s & 0.348s `cumtime`, respectively)
- ~83% faster `cumtime` in `will_accept` (0.745s -> 0.125s)
- ~44% faster `tottime` in `will_accept` (0.188s -> 0.106s)
- ~23% fewer calls to `len()` (1,523,012 -> 1,171,012) which gives similar speedups (24% -- 0.132s -> 0.100s `cumtime`)

It is worth noting that half of this overhead was just down to the naive deprecation shim I added in #40 which accessed `_accepted_names` twice...

## Current `v1` (b9a410974882bddb4661ab3764334eb431a45af1)

<details>

<summary>Show full baseline profile</summary>

```console
> python .local\bench.py
         10972072 function calls (9867072 primitive calls) in 7.148 seconds

   Ordered by: cumulative time

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.004    0.004    7.225    7.225	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.010    0.000    7.220    0.007	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
169000/2000		0.311    0.000    7.210    0.004	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
437000/211000		0.349    0.000    5.322    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000		0.335    0.000    5.097    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000		0.130    0.000    4.323    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.084    0.000    4.143    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:37(process)
   156000		2.940    0.000    3.937    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:45(parse)
53000/49000		0.079    0.000    2.323    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:85(process)
55000/53000		0.083    0.000    1.360    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:17(parse_condition)
   176000		0.188    0.000    0.745    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:119(will_accept)
   352012		0.155    0.000    0.535    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:69(_accepted_names)
4000/3000		0.003    0.000    0.516    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:36(process)
10000/1000		0.018    0.000    0.427    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:46(process)
   291000		0.138    0.000    0.375    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   352012		0.348    0.000    0.348    0.000	{built-in method _warnings.warn}
   447000		0.159    0.000    0.320    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:282(_flush_text_buffer)
108000/106000		0.084    0.000    0.273    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:68(process)
     5000		0.012    0.000    0.250    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:454(process)
   291000		0.196    0.000    0.237    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
     5000		0.003    0.000    0.211    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:482(_update_embed)
   876000		0.208    0.000    0.208    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
   491000		0.119    0.000    0.180    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
    39000		0.153    0.000    0.170    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
1523012/1508012		0.132    0.000    0.147    0.000	{built-in method builtins.len}
   108000		0.049    0.000    0.126    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
    55000		0.085    0.000    0.119    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:43(_find_zero_depth_operator)
115000/113000		0.060    0.000    0.117    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:48(will_accept)
     4000		0.006    0.000    0.112    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:61(process)
   146000		0.091    0.000    0.110    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:69(text)
     1000		0.003    0.000    0.107    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
   291000		0.064    0.000    0.088    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:225(_check_workload)
     1000		0.003    0.000    0.066    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\all_block.py:65(process)
   487022		0.066    0.000    0.066    0.000	{method 'lower' of 'str' objects}
   520001		0.065    0.000    0.065    0.000	{method 'append' of 'list' objects}
   108000		0.043    0.000    0.064    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:64(_handle_ctx)
   405000		0.062    0.000    0.062    0.000	{method 'get' of 'dict' objects}
   491000		0.061    0.000    0.061    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1765(isEnabledFor)
   437000		0.059    0.000    0.059    0.000	<string>:2(__init__)
     1000		0.000    0.000    0.051    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:102(_set_description)
     1000		0.002    0.000    0.045    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:134(_set_footer)
     1000		0.001    0.000    0.037    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\case_block.py:42(process)
    54000		0.016    0.000    0.025    0.000	<string>:1(<lambda>)
     5000		0.002    0.000    0.020    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:229(_return_embed)
   223000		0.020    0.000    0.020    0.000	ya_tagscript\src\ya_tagscript\interpreter\response.py:45(variables)
    36000		0.017    0.000    0.017    0.000	{method 'split' of 'str' objects}
    80001		0.017    0.000    0.017    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:54(__init__)
   136000		0.017    0.000    0.017    0.000	{method 'strip' of 'str' objects}
     5000		0.011    0.000    0.016    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:269(__len__)
    80000		0.015    0.000    0.015    0.000	ya_tagscript\src\ya_tagscript\interpreter\response.py:58(set_variable)
     1000		0.003    0.000    0.015    0.000	ya_tagscript\src\ya_tagscript\blocks\limiters\require_block.py:79(process)
     7000		0.008    0.000    0.014    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:171(_resolve_block_rejection)
   108000		0.013    0.000    0.013    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:93(_return_value)
    54000		0.010    0.000    0.010    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:65(_execute_operator)
    54000		0.010    0.000    0.010    0.000	{built-in method __new__ of type object at 0x00007FFA1AADAD90}
     1000		0.001    0.000    0.006    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:86(_set_colour)
     7000		0.004    0.000    0.004    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:31(as_raw_string)
     6000		0.004    0.000    0.004    0.000	{built-in method builtins.getattr}
     5000		0.003    0.000    0.004    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:181(__init__)
    15000		0.003    0.000    0.003    0.000	{method 'replace' of 'str' objects}
     1000		0.002    0.000    0.003    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:195(_string_to_colour)
    16000		0.002    0.000    0.002    0.000	ya_tagscript\src\ya_tagscript\blocks\meta\comment_block.py:44(process)
     1000		0.002    0.000    0.002    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:596(add_field)
     6000		0.001    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:338(colour)
     1000		0.001    0.000    0.001    0.000	{built-in method builtins.setattr}
     1000		0.000    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:585(fields)
     1000		0.001    0.000    0.001    0.000	ya_tagscript\src\ya_tagscript\blocks\actions\delete_block.py:69(process)
     5000		0.001    0.000    0.001    0.000	{method 'startswith' of 'str' objects}
     1000		0.001    0.000    0.001    0.000	ya_tagscript\src\ya_tagscript\interpreter\response.py:18(__init__)
     1000		0.000    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\colour.py:121(__init__)
     1000		0.001    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:377(set_footer)
     1000		0.000    0.000    0.000    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:173(_set_title)
     1000		0.000    0.000    0.000    0.000	{built-in method builtins.all}
     2000		0.000    0.000    0.000    0.000	{built-in method builtins.isinstance}
     1000		0.000    0.000    0.000    0.000	{method 'removeprefix' of 'str' objects}
     1000		0.000    0.000    0.000    0.000	{method 'keys' of 'dict' objects}
        1		0.000    0.000    0.000    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:38(__init__)
        1		0.000    0.000    0.000    0.000	{method 'disable' of '_lsprof.Profiler' objects}
        2		0.000    0.000    0.000    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1751(getEffectiveLevel)
        1		0.000    0.000    0.000    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:40(__init__)
        2		0.000    0.000    0.000    0.000	{method '__enter__' of '_thread.RLock' objects}
        2		0.000    0.000    0.000    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1354(disable)
        2		0.000    0.000    0.000    0.000	{method '__exit__' of '_thread.RLock' objects}
```

</details>

## Changes in this PR

<details>

<summary>Show full changed profile</summary>

```console
> python .local\bench.py
         9916048 function calls (8811048 primitive calls) in 6.471 seconds

   Ordered by: cumulative time

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005    6.548    6.548	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.010    0.000    6.543    0.007	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
169000/2000		0.305    0.000    6.531    0.003	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
437000/211000		0.338    0.000    4.640    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000		0.322    0.000    4.423    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000		0.129    0.000    4.017    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
   156000		2.944    0.000    3.932    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:45(parse)
    80000		0.081    0.000    3.844    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:37(process)
53000/49000		0.079    0.000    2.258    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:85(process)
55000/53000		0.080    0.000    1.324    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:17(parse_condition)
4000/3000		0.003    0.000    0.474    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:36(process)
10000/1000		0.018    0.000    0.389    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:46(process)
   291000		0.138    0.000    0.370    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   447000		0.160    0.000    0.318    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:282(_flush_text_buffer)
108000/106000		0.084    0.000    0.271    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:68(process)
     5000		0.012    0.000    0.244    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:454(process)
   291000		0.191    0.000    0.232    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
   876000		0.207    0.000    0.207    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:59(transition_state)
     5000		0.003    0.000    0.205    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:482(_update_embed)
   491000		0.116    0.000    0.176    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1498(debug)
    39000		0.152    0.000    0.168    0.000	ya_tagscript\src\ya_tagscript\util\splitter.py:1(split_at_substring_zero_depth)
   176000		0.106    0.000    0.125    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:86(will_accept)
   108000		0.048    0.000    0.124    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:61(get_value)
    55000		0.083    0.000    0.117    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:43(_find_zero_depth_operator)
115000/113000		0.059    0.000    0.116    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:48(will_accept)
1171012/1156012		0.100    0.000    0.114    0.000	{built-in method builtins.len}
     4000		0.006    0.000    0.110    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\python_block.py:61(process)
   146000		0.090    0.000    0.108    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:69(text)
     1000		0.003    0.000    0.106    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:16(_add_field)
   291000		0.063    0.000    0.088    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:225(_check_workload)
     1000		0.003    0.000    0.066    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\all_block.py:65(process)
   520001		0.064    0.000    0.064    0.000	{method 'append' of 'list' objects}
   108000		0.043    0.000    0.063    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:64(_handle_ctx)
   487022		0.061    0.000    0.061    0.000	{method 'lower' of 'str' objects}
   405000		0.060    0.000    0.060    0.000	{method 'get' of 'dict' objects}
   491000		0.059    0.000    0.059    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1765(isEnabledFor)
   437000		0.059    0.000    0.059    0.000	<string>:2(__init__)
     1000		0.000    0.000    0.046    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:102(_set_description)
     1000		0.002    0.000    0.044    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:134(_set_footer)
     1000		0.001    0.000    0.033    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\case_block.py:42(process)
    54000		0.015    0.000    0.025    0.000	<string>:1(<lambda>)
     5000		0.002    0.000    0.020    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:229(_return_embed)
   223000		0.020    0.000    0.020    0.000	ya_tagscript\src\ya_tagscript\interpreter\response.py:45(variables)
    36000		0.017    0.000    0.017    0.000	{method 'split' of 'str' objects}
    80001		0.017    0.000    0.017    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:54(__init__)
   136000		0.016    0.000    0.016    0.000	{method 'strip' of 'str' objects}
     5000		0.011    0.000    0.016    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:269(__len__)
    80000		0.015    0.000    0.015    0.000	ya_tagscript\src\ya_tagscript\interpreter\response.py:58(set_variable)
     1000		0.003    0.000    0.015    0.000	ya_tagscript\src\ya_tagscript\blocks\limiters\require_block.py:79(process)
     7000		0.008    0.000    0.014    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:171(_resolve_block_rejection)
   108000		0.012    0.000    0.012    0.000	ya_tagscript\src\ya_tagscript\adapters\string_adapter.py:93(_return_value)
    54000		0.010    0.000    0.010    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:65(_execute_operator)
    54000		0.010    0.000    0.010    0.000	{built-in method __new__ of type object at 0x00007FFA1AADAD90}
     1000		0.001    0.000    0.006    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:86(_set_colour)
     7000		0.004    0.000    0.004    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:31(as_raw_string)
     6000		0.004    0.000    0.004    0.000	{built-in method builtins.getattr}
     5000		0.003    0.000    0.004    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:181(__init__)
     1000		0.002    0.000    0.004    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:195(_string_to_colour)
    15000		0.003    0.000    0.003    0.000	{method 'replace' of 'str' objects}
    16000		0.002    0.000    0.002    0.000	ya_tagscript\src\ya_tagscript\blocks\meta\comment_block.py:44(process)
     1000		0.002    0.000    0.002    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:596(add_field)
     6000		0.001    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:338(colour)
     1000		0.001    0.000    0.001    0.000	{built-in method builtins.setattr}
     1000		0.001    0.000    0.001    0.000	ya_tagscript\src\ya_tagscript\blocks\actions\delete_block.py:69(process)
     1000		0.000    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:585(fields)
     5000		0.001    0.000    0.001    0.000	{method 'startswith' of 'str' objects}
     1000		0.001    0.000    0.001    0.000	ya_tagscript\src\ya_tagscript\interpreter\response.py:18(__init__)
     1000		0.000    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\colour.py:121(__init__)
     1000		0.001    0.000    0.001    0.000	ya_tagscript\.venv\Lib\site-packages\discord\embeds.py:377(set_footer)
     1000		0.000    0.000    0.000    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:173(_set_title)
     1000		0.000    0.000    0.000    0.000	{built-in method builtins.all}
     2000		0.000    0.000    0.000    0.000	{built-in method builtins.isinstance}
     1000		0.000    0.000    0.000    0.000	{method 'removeprefix' of 'str' objects}
     1000		0.000    0.000    0.000    0.000	{method 'keys' of 'dict' objects}
        1		0.000    0.000    0.000    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:38(__init__)
        1		0.000    0.000    0.000    0.000	{method 'disable' of '_lsprof.Profiler' objects}
        2		0.000    0.000    0.000    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1751(getEffectiveLevel)
        1		0.000    0.000    0.000    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:40(__init__)
        2		0.000    0.000    0.000    0.000	C:\Users\User\AppData\Local\Python\pythoncore-3.14-64\Lib\logging\__init__.py:1354(disable)
        2		0.000    0.000    0.000    0.000	{method '__enter__' of '_thread.RLock' objects}
        2		0.000    0.000    0.000    0.000	{method '__exit__' of '_thread.RLock' objects}
```