### PR TITLE
Add ACTIONS_KEY const to all actions-using Blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-*Currently none*
+- Added `ACTIONS_KEY` constants to all blocks which add data to the `Response.actions`
+  attribute as a typo-safe convenience.
 
 # v1.7.0 (2026-06-11)
 

--- a/docs/blocks.rst
+++ b/docs/blocks.rst
@@ -19,16 +19,22 @@ client. Characterised by adding data to the the
 :class:`~ya_tagscript.interpreter.Response` return value.
 
 .. autoclass:: CommandBlock
+    :members: ACTIONS_KEY
 
 .. autoclass:: DeleteBlock
+    :members: ACTIONS_KEY
 
 .. autoclass:: OverrideBlock
+    :members: ACTIONS_KEY
 
 .. autoclass:: ReactBlock
+    :members: ACTIONS_KEY
 
 .. autoclass:: RedirectBlock
+    :members: ACTIONS_KEY
 
 .. autoclass:: SilenceBlock
+    :members: ACTIONS_KEY
 
 ----
 
@@ -49,6 +55,7 @@ Discord Blocks
 .. autoclass:: CooldownBlock
 
 .. autoclass:: EmbedBlock
+    :members: ACTIONS_KEY
 
 ----
 
@@ -67,8 +74,10 @@ Limiter Blocks
 ==============
 
 .. autoclass:: BlacklistBlock
+    :members: ACTIONS_KEY
 
 .. autoclass:: RequireBlock
+    :members: ACTIONS_KEY
 
 ----
 

--- a/src/ya_tagscript/blocks/actions/command_block.py
+++ b/src/ya_tagscript/blocks/actions/command_block.py
@@ -33,11 +33,22 @@ class CommandBlock(BlockABC):
     - :attr:`~ya_tagscript.interpreter.Response.actions`
         - ``actions["commands"]``: :class:`list[str]` | :data:`None` — A list of
           command strings or :data:`None`
+        - The key is available via the
+          :attr:`CommandBlock.ACTIONS_KEY
+          <ya_tagscript.blocks.CommandBlock.ACTIONS_KEY>` class attribute
 
     Note:
         This block will only add the processed command strings to the ``commands``
         :attr:`~ya_tagscript.interpreter.Response.actions` key as shown above. It is
         *up to the client* to implement actual command execution behaviour as desired.
+    """
+
+    ACTIONS_KEY = "commands"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
     """
 
     _VALID_NAMES = {"c", "com", "cmd", "command"}
@@ -54,12 +65,12 @@ class CommandBlock(BlockABC):
 
         command = ctx.interpret_segment(payload)
 
-        commands: list[str] | None = ctx.response.actions.get("commands")
+        commands: list[str] | None = ctx.response.actions.get(CommandBlock.ACTIONS_KEY)
         if commands is not None:
             if len(commands) >= self.limit:
                 return f"`COMMAND LIMIT REACHED ({self.limit})`"
-            ctx.response.actions["commands"].append(command)
+            ctx.response.actions[CommandBlock.ACTIONS_KEY].append(command)
         else:
-            ctx.response.actions["commands"] = [command]
+            ctx.response.actions[CommandBlock.ACTIONS_KEY] = [command]
 
         return ""

--- a/src/ya_tagscript/blocks/actions/delete_block.py
+++ b/src/ya_tagscript/blocks/actions/delete_block.py
@@ -45,6 +45,9 @@ class DeleteBlock(BlockABC):
     - :attr:`~ya_tagscript.interpreter.Response.actions`
         - ``actions["delete"]``: :class:`bool` — Whether the invoking message should be
           deleted
+        - The key is available via the
+          :attr:`DeleteBlock.ACTIONS_KEY <ya_tagscript.blocks.DeleteBlock.ACTIONS_KEY>`
+          class attribute
 
     Note:
         This block will only set the ``delete``
@@ -53,10 +56,18 @@ class DeleteBlock(BlockABC):
         deletion behaviour as desired.
     """
 
+    ACTIONS_KEY = "delete"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
+    """
+
     _VALID_NAMES = {"delete", "del"}
 
     def process(self, ctx: Context) -> str | None:
-        if "delete" in ctx.response.actions.keys():
+        if DeleteBlock.ACTIONS_KEY in ctx.response.actions.keys():
             return ""
 
         value: bool | None
@@ -65,5 +76,5 @@ class DeleteBlock(BlockABC):
             value = True
         else:
             value = parse_condition(ctx, param)
-        ctx.response.actions["delete"] = value
+        ctx.response.actions[DeleteBlock.ACTIONS_KEY] = value
         return ""

--- a/src/ya_tagscript/blocks/actions/override_block.py
+++ b/src/ya_tagscript/blocks/actions/override_block.py
@@ -43,6 +43,9 @@ class OverrideBlock(BlockABC):
           :class:`dict[Literal["admin", "mod", "permissions"], bool]` — A dictionary
           like ``{"admin": bool, "mod": bool, "permissions": bool}`` where each
           attribute is either :data:`True` or :data:`False`
+        - The key is available via the
+          :attr:`OverrideBlock.ACTIONS_KEY
+          <ya_tagscript.blocks.OverrideBlock.ACTIONS_KEY>` class attribute
 
     Note:
         This block only sets the ``overrides``
@@ -52,12 +55,20 @@ class OverrideBlock(BlockABC):
         what permissions qualify for "admin", "mod", or "permissions".
     """
 
+    ACTIONS_KEY = "overrides"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
+    """
+
     _VALID_NAMES = {"override"}
 
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter
         if param is None:
-            ctx.response.actions["overrides"] = {
+            ctx.response.actions[OverrideBlock.ACTIONS_KEY] = {
                 "admin": True,
                 "mod": True,
                 "permissions": True,
@@ -69,9 +80,9 @@ class OverrideBlock(BlockABC):
             return None
 
         overrides = ctx.response.actions.get(
-            "overrides",
+            OverrideBlock.ACTIONS_KEY,
             {"admin": False, "mod": False, "permissions": False},
         )
         overrides[parsed_param] = True
-        ctx.response.actions["overrides"] = overrides
+        ctx.response.actions[OverrideBlock.ACTIONS_KEY] = overrides
         return ""

--- a/src/ya_tagscript/blocks/actions/react_block.py
+++ b/src/ya_tagscript/blocks/actions/react_block.py
@@ -62,6 +62,9 @@ class ReactBlock(BlockABC):
           :class:`dict[Literal["input", "output"], list[str]]` — A dictionary like
           ``{"input": [...], "output": [...]}`` (each key may be missing if it wasn't
           used in the script)
+        - The key is available via the
+          :attr:`ReactBlock.ACTIONS_KEY <ya_tagscript.blocks.ReactBlock.ACTIONS_KEY>`
+          class attribute
 
     Note:
         This block will only set the provided string(s) in the ``reactions``
@@ -69,6 +72,14 @@ class ReactBlock(BlockABC):
         dictionary key as shown above. Each of the keys may be missing if not used in
         the script. It is *up to the client* to implement actual reaction adding
         behaviour as desired.
+    """
+
+    ACTIONS_KEY = "reactions"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
     """
 
     _VALID_NAMES = {"react", "reactu"}
@@ -97,13 +108,13 @@ class ReactBlock(BlockABC):
             return f"`Reaction Limit Reached ({self.limit})`"
 
         if parsed_declaration == "react":
-            reactions_dict = ctx.response.actions.get("reactions", {})
+            reactions_dict = ctx.response.actions.get(ReactBlock.ACTIONS_KEY, {})
             reactions_dict.update({"output": reactions})
-            ctx.response.actions["reactions"] = reactions_dict
+            ctx.response.actions[ReactBlock.ACTIONS_KEY] = reactions_dict
         elif parsed_declaration == "reactu":
-            reactions_dict = ctx.response.actions.get("reactions", {})
+            reactions_dict = ctx.response.actions.get(ReactBlock.ACTIONS_KEY, {})
             reactions_dict.update({"input": reactions})
-            ctx.response.actions["reactions"] = reactions_dict
+            ctx.response.actions[ReactBlock.ACTIONS_KEY] = reactions_dict
         else:
             return None
         return ""

--- a/src/ya_tagscript/blocks/actions/redirect_block.py
+++ b/src/ya_tagscript/blocks/actions/redirect_block.py
@@ -48,6 +48,9 @@ class RedirectBlock(BlockABC):
     - :attr:`~ya_tagscript.interpreter.Response.actions`
         - ``actions["target"]``: :class:`Literal["dm", "reply"]` | :class:`str` — A
           string indicating the redirection target
+        - The key is available via the
+          :attr:`RedirectBlock.ACTIONS_KEY
+          <ya_tagscript.blocks.RedirectBlock.ACTIONS_KEY>` class attribute
 
     Note:
         This block will only set the ``target``
@@ -55,6 +58,14 @@ class RedirectBlock(BlockABC):
         *up to the client* to implement actual redirection behaviour, including what
         constitutes a valid ``channel`` input (a client may choose to only accept IDs
         and reject channel names, for example).
+    """
+
+    ACTIONS_KEY = "target"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
     """
 
     _VALID_NAMES = {"redirect"}
@@ -75,5 +86,5 @@ class RedirectBlock(BlockABC):
             target = "reply"
         else:
             target = parsed_param
-        ctx.response.actions["target"] = target
+        ctx.response.actions[RedirectBlock.ACTIONS_KEY] = target
         return ""

--- a/src/ya_tagscript/blocks/actions/silence_block.py
+++ b/src/ya_tagscript/blocks/actions/silence_block.py
@@ -35,6 +35,9 @@ class SilenceBlock(BlockABC):
     - :attr:`~ya_tagscript.interpreter.Response.actions`
         - ``actions["silent"]``: :class:`Literal[True]` — Always :data:`True` if a
           SilenceBlock was used
+        - The key is available via the
+          :attr:`SilenceBlock.ACTIONS_KEY
+          <ya_tagscript.blocks.SilenceBlock.ACTIONS_KEY>` class attribute
 
     Note:
         This block will only set the ``silent``
@@ -44,8 +47,16 @@ class SilenceBlock(BlockABC):
         this is **not** recommended.
     """
 
+    ACTIONS_KEY = "silent"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
+    """
+
     _VALID_NAMES = {"silent", "silence"}
 
     def process(self, ctx: Context) -> str | None:
-        ctx.response.actions["silent"] = True
+        ctx.response.actions[SilenceBlock.ACTIONS_KEY] = True
         return ""

--- a/src/ya_tagscript/blocks/discord/embed_block.py
+++ b/src/ya_tagscript/blocks/discord/embed_block.py
@@ -233,7 +233,7 @@ def _return_embed(ctx: Context, embed: Embed) -> str:
         return str(e)
     if size > 6000:
         return f"`MAX EMBED LENGTH REACHED ({size}/6000)`"
-    ctx.response.actions["embed"] = embed
+    ctx.response.actions[EmbedBlock.ACTIONS_KEY] = embed
     return ""
 
 
@@ -418,10 +418,21 @@ class EmbedBlock(BlockABC):
     - :attr:`~ya_tagscript.interpreter.Response.actions`
         - ``actions["embed"]``: :class:`discord.Embed` — The constructed
           :class:`discord.Embed`
+        - The key is available via the
+          :attr:`EmbedBlock.ACTIONS_KEY <ya_tagscript.blocks.EmbedBlock.ACTIONS_KEY>`
+          class attribute
 
     Note:
         This block only sets the ``embed`` actions key as shown above. It is *up to the
         client* to actually send the :class:`discord.Embed` object being constructed.
+    """
+
+    ACTIONS_KEY = "embed"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
     """
 
     _VALID_NAMES = {"embed"}
@@ -443,7 +454,10 @@ class EmbedBlock(BlockABC):
     def process(self, ctx: Context) -> str | None:
         param = ctx.node.parameter
         if param is None:
-            return _return_embed(ctx, ctx.response.actions.get("embed", Embed()))
+            return _return_embed(
+                ctx,
+                ctx.response.actions.get(EmbedBlock.ACTIONS_KEY, Embed()),
+            )
 
         parsed_param = ctx.interpret_segment(param)
         lowercase_param = parsed_param.lower()
@@ -451,7 +465,7 @@ class EmbedBlock(BlockABC):
             if lowercase_param.startswith("{") and lowercase_param.endswith("}"):
                 embed = _json_to_embed(parsed_param)
             elif lowercase_param in self.ATTRIBUTE_HANDLERS:
-                embed = ctx.response.actions.get("embed", Embed())
+                embed = ctx.response.actions.get(EmbedBlock.ACTIONS_KEY, Embed())
                 embed = self._update_embed(
                     ctx,
                     embed,

--- a/src/ya_tagscript/blocks/limiters/blacklist_block.py
+++ b/src/ya_tagscript/blocks/limiters/blacklist_block.py
@@ -50,6 +50,9 @@ class BlacklistBlock(BlockABC):
           - ``"items"``: A list of strings representing channels or roles
           - ``"response"``: A response :class:`str` OR :data:`None` if no ``response``
             was provided to the block
+        - The key is available via the
+          :attr:`BlacklistBlock.ACTIONS_KEY
+          <ya_tagscript.blocks.BlacklistBlock.ACTIONS_KEY>` class attribute
 
     Note:
         This block only adds the blacklist information in the ``blacklist`` actions
@@ -57,6 +60,14 @@ class BlacklistBlock(BlockABC):
         actual blacklist blocking system. It is also the *client's responsibility* to
         prevent side effects like commands, reactions, etc. from being executed if the
         tag execution is blacklisted somehow.
+    """
+
+    ACTIONS_KEY = "blacklist"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
     """
 
     _VALID_NAMES = {"blacklist"}
@@ -67,7 +78,7 @@ class BlacklistBlock(BlockABC):
         param = ctx.node.parameter
         if param is None or param.strip() == "":
             return None
-        elif ctx.response.actions.get("blacklist") is not None:
+        elif ctx.response.actions.get(BlacklistBlock.ACTIONS_KEY) is not None:
             return None
 
         parsed_param = ctx.interpret_segment(param)
@@ -76,7 +87,7 @@ class BlacklistBlock(BlockABC):
         response = None
         if ctx.node.payload is not None:
             response = ctx.interpret_segment(ctx.node.payload)
-        ctx.response.actions["blacklist"] = {
+        ctx.response.actions[BlacklistBlock.ACTIONS_KEY] = {
             "items": [b.strip() for b in split],
             "response": response,
         }

--- a/src/ya_tagscript/blocks/limiters/require_block.py
+++ b/src/ya_tagscript/blocks/limiters/require_block.py
@@ -52,6 +52,9 @@ class RequireBlock(BlockABC):
           - ``"items"``: A list of strings representing channels or roles
           - ``"response"``: A response :class:`str` OR :data:`None` if no ``response``
             was provided to the block
+        - The key is available via the
+          :attr:`RequireBlock.ACTIONS_KEY
+          <ya_tagscript.blocks.RequireBlock.ACTIONS_KEY>` class attribute
 
     Note:
         This block only adds the requirement information in the ``requires`` actions
@@ -59,6 +62,14 @@ class RequireBlock(BlockABC):
         actual requirement enforcement system. It is also the *client's responsibility*
         to prevent side effects like commands, reactions, etc. from being executed if
         the tag execution does not meet the requirements and is therefore blocked.
+    """
+
+    ACTIONS_KEY = "requires"
+    """
+    The key used to store data in the
+    :attr:`Response.actions <ya_tagscript.interpreter.Response.actions>`.
+
+    .. versionadded:: 1.7.1
     """
 
     _VALID_NAMES = {"require", "whitelist"}
@@ -69,7 +80,7 @@ class RequireBlock(BlockABC):
         param = ctx.node.parameter
         if param is None or param.strip() == "":
             return None
-        elif ctx.response.actions.get("requires") is not None:
+        elif ctx.response.actions.get(RequireBlock.ACTIONS_KEY) is not None:
             return None
 
         parsed_param = ctx.interpret_segment(param)
@@ -78,7 +89,7 @@ class RequireBlock(BlockABC):
         response = None
         if ctx.node.payload is not None:
             response = ctx.interpret_segment(ctx.node.payload)
-        ctx.response.actions["requires"] = {
+        ctx.response.actions[RequireBlock.ACTIONS_KEY] = {
             "items": [r.strip() for r in split],
             "response": response,
         }

--- a/tests/ya_tagscript/blocks/actions/test_command_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_command_block.py
@@ -50,7 +50,7 @@ def test_dec_command_docs_example_one(
 ):
     script = "{command:ping}"
     response = ts_interpreter.process(script)
-    assert response.actions.get("commands", []) == ["ping"]
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY, []) == ["ping"]
     assert response.body == ""
 
 
@@ -61,7 +61,9 @@ def test_dec_command_docs_example_two(
     data = {"target": adapters.AttributeAdapter(MagicMock(id=42))}
     response = ts_interpreter.process(script, data)
     assert response.body == ""
-    assert response.actions.get("commands", []) == ["ban 42 flooding/spam"]
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY, []) == [
+        "ban 42 flooding/spam",
+    ]
 
 
 def test_dec_command_empty_payload_is_rejected(
@@ -69,7 +71,7 @@ def test_dec_command_empty_payload_is_rejected(
 ):
     script = "{command:}"
     response = ts_interpreter.process(script)
-    assert response.actions.get("commands") is None
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) is None
     assert response.body == script
 
 
@@ -78,7 +80,7 @@ def test_dec_command_missing_payload_is_rejected(
 ):
     script = "{command}"
     response = ts_interpreter.process(script)
-    assert response.actions.get("commands") is None
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) is None
     assert response.body == script
 
 
@@ -97,5 +99,5 @@ def test_dec_command_payload_is_interpreted(
     data = {"world": adapters.StringAdapter("everyone")}
     response = ts_interpreter.process(script, data)
     assert response.body == ""
-    commands = response.actions.get("commands", [])
+    commands = response.actions.get(blocks.CommandBlock.ACTIONS_KEY, [])
     assert commands == ["Hello everyone"]

--- a/tests/ya_tagscript/blocks/actions/test_delete_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_delete_block.py
@@ -30,7 +30,7 @@ def test_dec_delete_duplicated_uses_dont_matter(
     script = "{delete}{delete}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("delete")
+    assert response.actions.get(blocks.DeleteBlock.ACTIONS_KEY)
 
 
 def test_dec_delete_docs_example_one(
@@ -39,7 +39,7 @@ def test_dec_delete_docs_example_one(
     script = "{delete}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("delete")
+    assert response.actions.get(blocks.DeleteBlock.ACTIONS_KEY)
 
 
 def test_dec_delete_docs_example_two(
@@ -48,7 +48,7 @@ def test_dec_delete_docs_example_two(
     script = "{delete(true==true)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("delete")
+    assert response.actions.get(blocks.DeleteBlock.ACTIONS_KEY)
 
 
 def test_dec_delete_falsy_param(
@@ -57,7 +57,7 @@ def test_dec_delete_falsy_param(
     script = "{delete(true==false)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert not response.actions.get("delete")
+    assert not response.actions.get(blocks.DeleteBlock.ACTIONS_KEY)
 
 
 def test_dec_delete_nested_parameter_is_parsed_correctly(
@@ -66,7 +66,7 @@ def test_dec_delete_nested_parameter_is_parsed_correctly(
     script = "{=(second):2}{delete({=(first):1}{first}!={second})}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("delete")
+    assert response.actions.get(blocks.DeleteBlock.ACTIONS_KEY)
 
 
 def test_dec_delete_parameter_is_interpreted(
@@ -76,4 +76,4 @@ def test_dec_delete_parameter_is_interpreted(
     data = {"myvar": adapters.StringAdapter("true")}
     response = ts_interpreter.process(script, data)
     assert response.body == ""
-    assert response.actions.get("delete")
+    assert response.actions.get(blocks.DeleteBlock.ACTIONS_KEY)

--- a/tests/ya_tagscript/blocks/actions/test_react_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_react_block.py
@@ -86,7 +86,7 @@ def test_dec_react_docs_example_one(
     script = "{react:💩}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {"output": ["💩"]}
 
@@ -97,7 +97,7 @@ def test_dec_reactu_docs_example_one(
     script = "{reactu:👍}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {"input": ["👍"]}
 
@@ -108,7 +108,7 @@ def test_dec_react_docs_example_two(
     script = "{react:💩 :)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {"output": ["💩", ":)"]}
 
@@ -119,7 +119,7 @@ def test_dec_reactu_docs_example_two(
     script = "{reactu:👍 ⏰}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {"input": ["👍", "⏰"]}
 
@@ -130,7 +130,7 @@ def test_dec_react_docs_example_three(
     script = "{react:💩 :) :D}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {"output": ["💩", ":)", ":D"]}
 
@@ -141,7 +141,7 @@ def test_dec_reactu_docs_example_three(
     script = "{reactu:👍 ⏰ 🦚}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {"input": ["👍", "⏰", "🦚"]}
 
@@ -152,7 +152,7 @@ def test_dec_react_reactu_can_be_used_together(
     script = "{react:☕ 🤔}{reactu:🦚 🦫 💪}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {
         "input": ["🦚", "🦫", "💪"],
@@ -175,7 +175,7 @@ def test_both_repeated_use_overwrites_previous_emoji(
     script = f"{{{variant}:🦚}}{{{variant}:🦫}}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {out_key: ["🦫"]}
 
@@ -191,7 +191,7 @@ def test_both_empty_payload_is_rejected(
     script = f"{{{variant}:}}"
     response = ts_interpreter.process(script)
     assert response.body == script
-    assert response.actions.get("reactions") is None
+    assert response.actions.get(blocks.ReactBlock.ACTIONS_KEY) is None
 
 
 @pytest.mark.parametrize(
@@ -205,7 +205,7 @@ def test_both_limit_is_enforced(
     script = f"{{{variant}:✅ ☕ 🤔 👍 😅 💩}}"
     response = ts_interpreter.process(script)
     assert response.body == "`Reaction Limit Reached (5)`"
-    assert response.actions.get("reactions") is None
+    assert response.actions.get(blocks.ReactBlock.ACTIONS_KEY) is None
 
 
 @pytest.mark.parametrize(
@@ -230,7 +230,7 @@ def test_both_limit_is_enforced_per_variant_not_globally(
     )
     response = ts_interpreter.process(script)
     assert response.body == "`Reaction Limit Reached (5)`"
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {out_key: ["☕", "🤔", "👍", "😅"]}
 
@@ -250,7 +250,7 @@ def test_both_duplicate_spaces_between_emoji_are_ignored(
     script = f"{{{variant}:         ✅   ☕     🦫    ♥️                  ⏰    }}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {out_key: ["✅", "☕", "🦫", "♥️", "⏰"]}
 
@@ -270,7 +270,7 @@ def test_both_nested_payload_is_parsed_and_split_correctly(
     script = "{" + variant + ":{=(a):A}{=(b):{a} B}{b}}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {out_key: ["A", "B"]}
 
@@ -291,6 +291,6 @@ def test_both_payload_is_interpreted(
     data = {"myvar": adapters.StringAdapter(":waving:")}
     response = ts_interpreter.process(script, data)
     assert response.body == ""
-    reactions = response.actions.get("reactions")
+    reactions = response.actions.get(blocks.ReactBlock.ACTIONS_KEY)
     assert reactions is not None
     assert reactions == {out_key: [":waving:"]}

--- a/tests/ya_tagscript/blocks/actions/test_redirect_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_redirect_block.py
@@ -61,7 +61,7 @@ def test_dec_redirect_docs_example_one(
     script = "{redirect(dm)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("target") == "dm"
+    assert response.actions.get(blocks.RedirectBlock.ACTIONS_KEY) == "dm"
 
 
 def test_dec_redirect_docs_example_two(
@@ -70,7 +70,7 @@ def test_dec_redirect_docs_example_two(
     script = "{redirect(reply)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("target") == "reply"
+    assert response.actions.get(blocks.RedirectBlock.ACTIONS_KEY) == "reply"
 
 
 def test_dec_redirect_docs_example_three(
@@ -79,7 +79,7 @@ def test_dec_redirect_docs_example_three(
     script = "{redirect(#general)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("target") == "#general"
+    assert response.actions.get(blocks.RedirectBlock.ACTIONS_KEY) == "#general"
 
 
 def test_dec_redirect_docs_example_four(
@@ -88,7 +88,9 @@ def test_dec_redirect_docs_example_four(
     script = "{redirect(1195734229506601003)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("target") == "1195734229506601003"
+    assert (
+        response.actions.get(blocks.RedirectBlock.ACTIONS_KEY) == "1195734229506601003"
+    )
 
 
 def test_dec_redirect_repeated_use_overwrites_previous_target(
@@ -97,7 +99,7 @@ def test_dec_redirect_repeated_use_overwrites_previous_target(
     script = "{redirect(dm)}{redirect(reply)}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("target") == "reply"
+    assert response.actions.get(blocks.RedirectBlock.ACTIONS_KEY) == "reply"
 
 
 def test_dec_redirect_parameter_is_interpreted(
@@ -107,4 +109,4 @@ def test_dec_redirect_parameter_is_interpreted(
     data = {"myvar": adapters.StringAdapter("dm")}
     response = ts_interpreter.process(script, data)
     assert response.body == ""
-    assert response.actions.get("target") == "dm"
+    assert response.actions.get(blocks.RedirectBlock.ACTIONS_KEY) == "dm"

--- a/tests/ya_tagscript/blocks/actions/test_silence_block.py
+++ b/tests/ya_tagscript/blocks/actions/test_silence_block.py
@@ -28,4 +28,4 @@ def test_dec_silence_sets_silence_action(
     script = "{silence}"
     response = ts_interpreter.process(script)
     assert response.body == ""
-    assert response.actions.get("silent")
+    assert response.actions.get(blocks.SilenceBlock.ACTIONS_KEY)

--- a/tests/ya_tagscript/blocks/conditional/test_all_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_all_block.py
@@ -231,4 +231,4 @@ def test_dec_all_side_effect_avoidance(
     data = {"args": adapters.StringAdapter("blah")}
     response = ts_interpreter.process(script, data)
     assert response.body == "something else"
-    assert response.actions.get("commands") is None
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) is None

--- a/tests/ya_tagscript/blocks/conditional/test_any_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_any_block.py
@@ -237,4 +237,4 @@ def test_dec_any_side_effect_avoidance(
     data = {"args": adapters.StringAdapter("blah")}
     response = ts_interpreter.process(script, data)
     assert response.body == "something else"
-    assert response.actions.get("commands") is None
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) is None

--- a/tests/ya_tagscript/blocks/conditional/test_if_block.py
+++ b/tests/ya_tagscript/blocks/conditional/test_if_block.py
@@ -251,4 +251,4 @@ def test_dec_if_readme_example_side_effect_avoidance(
     data = {"args": adapters.StringAdapter("blah")}
     response = ts_interpreter.process(script, data)
     assert response.body == "something else"
-    assert response.actions.get("commands") is None
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) is None

--- a/tests/ya_tagscript/blocks/flow/test_stop_block.py
+++ b/tests/ya_tagscript/blocks/flow/test_stop_block.py
@@ -102,7 +102,7 @@ def test_dec_stop_parsing_is_stopped_immediately(
     data = {"args": adapters.StringAdapter("")}
     response = ts_interpreter.process(script, data)
     assert response.body == "You must provide arguments for this tag."
-    assert response.actions.get("commands") is None
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) is None
 
 
 def test_dec_stop_parsing_only_stops_on_stop_block(
@@ -116,7 +116,9 @@ def test_dec_stop_parsing_only_stops_on_stop_block(
     data = {"args": adapters.StringAdapter("")}
     response = ts_interpreter.process(script, data)
     assert response.body == "You must provide arguments for this tag."
-    assert response.actions.get("commands") == ["a reachable command"]
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) == [
+        "a reachable command",
+    ]
 
 
 def test_dec_stop_message_replaces_entire_output(

--- a/tests/ya_tagscript/blocks/meta/test_comment_block.py
+++ b/tests/ya_tagscript/blocks/meta/test_comment_block.py
@@ -62,5 +62,5 @@ def test_dec_comment_docs_example_three(
 ):
     script = "{comment:{cmd:echo hello world}}{cmd:ping}"
     response = ts_interpreter_with_cmd_block.process(script)
-    assert response.actions.get("commands") == ["ping"]
+    assert response.actions.get(blocks.CommandBlock.ACTIONS_KEY) == ["ping"]
     assert response.body == ""


### PR DESCRIPTION
This allows clients to access the data in `Response.actions` in a typo-safe manner.

Nothing has changed about library behaviour, though the Blocks all use their constants internally now.