### PR TITLE
Enable isort `--sort-reexports` option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,6 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 8.0.1
+    rev: 9.0.0b1
     hooks:
       - id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ relative_files = true
 profile = "black"
 py_version = 311
 reverse_relative = true
+sort_reexports = true
 
 [tool.mypy]
 strict = true

--- a/src/ya_tagscript/__init__.py
+++ b/src/ya_tagscript/__init__.py
@@ -1,6 +1,3 @@
 from .interpreter import Response, TagScriptInterpreter
 
-__all__ = (
-    "Response",
-    "TagScriptInterpreter",
-)
+__all__ = ("Response", "TagScriptInterpreter")

--- a/src/ya_tagscript/adapters/discord_adapters/__init__.py
+++ b/src/ya_tagscript/adapters/discord_adapters/__init__.py
@@ -3,9 +3,4 @@ from .channel_adapter import ChannelAdapter
 from .guild_adapter import GuildAdapter
 from .member_adapter import MemberAdapter
 
-__all__ = (
-    "AttributeAdapter",
-    "ChannelAdapter",
-    "GuildAdapter",
-    "MemberAdapter",
-)
+__all__ = ("AttributeAdapter", "ChannelAdapter", "GuildAdapter", "MemberAdapter")

--- a/src/ya_tagscript/blocks/conditional/__init__.py
+++ b/src/ya_tagscript/blocks/conditional/__init__.py
@@ -2,8 +2,4 @@ from .all_block import AllBlock
 from .any_block import AnyBlock
 from .if_block import IfBlock
 
-__all__ = (
-    "AllBlock",
-    "AnyBlock",
-    "IfBlock",
-)
+__all__ = ("AllBlock", "AnyBlock", "IfBlock")

--- a/src/ya_tagscript/blocks/discord/__init__.py
+++ b/src/ya_tagscript/blocks/discord/__init__.py
@@ -1,7 +1,4 @@
 from .cooldown_block import CooldownBlock
 from .embed_block import EmbedBlock
 
-__all__ = (
-    "CooldownBlock",
-    "EmbedBlock",
-)
+__all__ = ("CooldownBlock", "EmbedBlock")

--- a/src/ya_tagscript/blocks/flow/__init__.py
+++ b/src/ya_tagscript/blocks/flow/__init__.py
@@ -2,8 +2,4 @@ from .break_block import BreakBlock
 from .shortcutredirect_block import ShortcutRedirectBlock
 from .stop_block import StopBlock
 
-__all__ = (
-    "BreakBlock",
-    "ShortcutRedirectBlock",
-    "StopBlock",
-)
+__all__ = ("BreakBlock", "ShortcutRedirectBlock", "StopBlock")

--- a/src/ya_tagscript/blocks/limiters/__init__.py
+++ b/src/ya_tagscript/blocks/limiters/__init__.py
@@ -1,7 +1,4 @@
 from .blacklist_block import BlacklistBlock
 from .require_block import RequireBlock
 
-__all__ = (
-    "BlacklistBlock",
-    "RequireBlock",
-)
+__all__ = ("BlacklistBlock", "RequireBlock")

--- a/src/ya_tagscript/blocks/lists/__init__.py
+++ b/src/ya_tagscript/blocks/lists/__init__.py
@@ -1,7 +1,4 @@
 from .cycle_block import CycleBlock
 from .list_block import ListBlock
 
-__all__ = (
-    "CycleBlock",
-    "ListBlock",
-)
+__all__ = ("CycleBlock", "ListBlock")

--- a/src/ya_tagscript/blocks/math/__init__.py
+++ b/src/ya_tagscript/blocks/math/__init__.py
@@ -1,7 +1,4 @@
 from .math_block import MathBlock
 from .ordinal_block import OrdinalBlock
 
-__all__ = (
-    "MathBlock",
-    "OrdinalBlock",
-)
+__all__ = ("MathBlock", "OrdinalBlock")

--- a/src/ya_tagscript/blocks/meta/__init__.py
+++ b/src/ya_tagscript/blocks/meta/__init__.py
@@ -1,7 +1,4 @@
 from .comment_block import CommentBlock
 from .debug_block import DebugBlock
 
-__all__ = (
-    "CommentBlock",
-    "DebugBlock",
-)
+__all__ = ("CommentBlock", "DebugBlock")

--- a/src/ya_tagscript/blocks/rng/__init__.py
+++ b/src/ya_tagscript/blocks/rng/__init__.py
@@ -2,8 +2,4 @@ from .fiftyfifty_block import FiftyFiftyBlock
 from .random_block import RandomBlock
 from .range_block import RangeBlock
 
-__all__ = (
-    "FiftyFiftyBlock",
-    "RandomBlock",
-    "RangeBlock",
-)
+__all__ = ("FiftyFiftyBlock", "RandomBlock", "RangeBlock")

--- a/src/ya_tagscript/blocks/time/__init__.py
+++ b/src/ya_tagscript/blocks/time/__init__.py
@@ -1,7 +1,4 @@
 from .strf_block import StrfBlock
 from .timedelta_block import TimedeltaBlock
 
-__all__ = (
-    "StrfBlock",
-    "TimedeltaBlock",
-)
+__all__ = ("StrfBlock", "TimedeltaBlock")

--- a/src/ya_tagscript/blocks/variables/__init__.py
+++ b/src/ya_tagscript/blocks/variables/__init__.py
@@ -2,8 +2,4 @@ from .assign_block import AssignmentBlock
 from .loose_variable_getter_block import LooseVariableGetterBlock
 from .strict_variable_getter_block import StrictVariableGetterBlock
 
-__all__ = (
-    "AssignmentBlock",
-    "LooseVariableGetterBlock",
-    "StrictVariableGetterBlock",
-)
+__all__ = ("AssignmentBlock", "LooseVariableGetterBlock", "StrictVariableGetterBlock")

--- a/src/ya_tagscript/interfaces/__init__.py
+++ b/src/ya_tagscript/interfaces/__init__.py
@@ -3,10 +3,4 @@ from .blockabc import BlockABC
 from .interpreterabc import InterpreterABC
 from .nodeabc import NodeABC, NodeType
 
-__all__ = (
-    "AdapterABC",
-    "BlockABC",
-    "InterpreterABC",
-    "NodeABC",
-    "NodeType",
-)
+__all__ = ("AdapterABC", "BlockABC", "InterpreterABC", "NodeABC", "NodeType")

--- a/src/ya_tagscript/interpreter/__init__.py
+++ b/src/ya_tagscript/interpreter/__init__.py
@@ -3,9 +3,4 @@ from .interpreter import TagScriptInterpreter
 from .node import Node
 from .response import Response
 
-__all__ = (
-    "Context",
-    "Node",
-    "Response",
-    "TagScriptInterpreter",
-)
+__all__ = ("Context", "Node", "Response", "TagScriptInterpreter")

--- a/src/ya_tagscript/util/__init__.py
+++ b/src/ya_tagscript/util/__init__.py
@@ -2,8 +2,4 @@ from .conditionals import parse_condition
 from .escaping import escape_content
 from .splitter import split_at_substring_zero_depth
 
-__all__ = (
-    "escape_content",
-    "parse_condition",
-    "split_at_substring_zero_depth",
-)
+__all__ = ("escape_content", "parse_condition", "split_at_substring_zero_depth")


### PR DESCRIPTION
Can't currently enable this on the `v1` branch because isort does not respect the trailing commas of short `__all__` exports and I'd quite like to keep those.

See https://github.com/PyCQA/isort/issues/2578

Uses the 9.0.0b1 release for some black-related fixes but the option itself has existed for a long time.

Edit: The unkept trailing commas can be see in the pre-commit.ci fixes to this PR in 9d58fd2.