### PR TITLE
Add more fast paths in parsing loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-*Currently none*
+- More parsing loop performance improvements
 
 # v1.7.1 (2026-07-03)
 

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -29,6 +29,8 @@ _SPECIAL_TOKENS: set[str] = {
     PAREN_CLOSE,
     COLON,
 }
+# COLON isn't special in several places
+_SPECIAL_TOKENS_NO_COLON = _SPECIAL_TOKENS - {COLON}
 
 
 class TagScriptParser:
@@ -48,6 +50,7 @@ class TagScriptParser:
         i = 0
         input_len = len(input_str)
         special_chars = _SPECIAL_TOKENS
+        specials_no_colon = _SPECIAL_TOKENS_NO_COLON
 
         # region processing loop
         # this is an extremely hot loop so there are additional local references to
@@ -124,7 +127,16 @@ class TagScriptParser:
                     block.declaration = char
 
             elif current_state is ParseState.IN_DECLARATION:
-                if char == BRACE_OPEN:
+                if char not in special_chars:
+                    # covers BACKSLASH and any other char
+                    # fast-path accumulation
+                    start = i
+                    while i < input_len and input_str[i] not in special_chars:
+                        i += 1
+                    block.declaration = (block.declaration or "") + input_str[start:i]
+                    char = input_str[i - 1]
+                    continue
+                elif char == BRACE_OPEN:
                     if not is_escaped:
                         block.block_depth += 1
                     block.declaration = (block.declaration or "") + char
@@ -157,10 +169,19 @@ class TagScriptParser:
                     else:
                         block.declaration = (block.declaration or "") + char
                 else:
-                    block.declaration = (block.declaration or "") + char
+                    raise ValueError(f"Unknown special char {char!r} in IN_DECLARATION")
 
             elif current_state is ParseState.IN_PARAMETER:
-                if char == BRACE_OPEN:
+                if char not in specials_no_colon:
+                    # covers BACKSLASH, COLON, any other char
+                    # fast-path accumulation
+                    start = i
+                    while i < input_len and input_str[i] not in specials_no_colon:
+                        i += 1
+                    block.parameter = (block.parameter or "") + input_str[start:i]
+                    char = input_str[i - 1]
+                    continue
+                elif char == BRACE_OPEN:
                     if not is_escaped:
                         block.block_depth += 1
                     block.parameter = (block.parameter or "") + char
@@ -187,8 +208,7 @@ class TagScriptParser:
                         block.parameter = (block.parameter or "") + char
                     block.paren_depth -= 1
                 else:
-                    # includes BACKSLASH, COLON, any other char
-                    block.parameter = (block.parameter or "") + char
+                    raise ValueError(f"Unknown special char {char!r} in IN_PARAMETER")
 
             elif current_state is ParseState.POST_PARAMETER:
                 if char == BRACE_CLOSE and block.block_depth == 1:
@@ -207,7 +227,16 @@ class TagScriptParser:
                     self._state = None
 
             elif current_state is ParseState.IN_PAYLOAD:
-                if char == BRACE_OPEN:
+                if char not in specials_no_colon:
+                    # covers BACKSLASH, COLON, any other char
+                    # fast-path accumulation
+                    start = i
+                    while i < input_len and input_str[i] not in specials_no_colon:
+                        i += 1
+                    block.payload = (block.payload or "") + input_str[start:i]
+                    char = input_str[i - 1]
+                    continue
+                elif char == BRACE_OPEN:
                     if not is_escaped:
                         block.block_depth += 1
                     block.payload = (block.payload or "") + char
@@ -230,8 +259,8 @@ class TagScriptParser:
                     if block.paren_depth > 0:
                         block.paren_depth -= 1
                 else:
-                    # covers BACKSLASH, COLON, any other char
-                    block.payload = (block.payload or "") + char
+                    raise ValueError(f"Unknown special char {char!r} in IN_PAYLOAD")
+
             else:
                 assert_never(current_state)
 

--- a/tests/ya_tagscript/interpreter/test_ts_parser.py
+++ b/tests/ya_tagscript/interpreter/test_ts_parser.py
@@ -3,10 +3,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ya_tagscript.interpreter import ts_parser
 from ya_tagscript.interpreter.node import Node
 
 # noinspection PyProtectedMember
 from ya_tagscript.interpreter.ts_parser import (
+    _SPECIAL_TOKENS,
+    _SPECIAL_TOKENS_NO_COLON,
     TagScriptParser,
     _reconstruct_partial_block,
 )
@@ -24,6 +27,24 @@ def mock_reconstruct_fn():
         wraps=_reconstruct_partial_block,
     ) as mocked_fn:
         yield mocked_fn
+
+
+@pytest.fixture
+def mock_special_tokens():
+    # don't look at it
+    with patch.object(ts_parser, "_SPECIAL_TOKENS", _SPECIAL_TOKENS.union({"~"})):
+        yield
+
+
+@pytest.fixture
+def mock_special_tokens_no_colon():
+    # don't look at it
+    with patch.object(
+        ts_parser,
+        "_SPECIAL_TOKENS_NO_COLON",
+        _SPECIAL_TOKENS_NO_COLON.union({"~"}),
+    ):
+        yield
 
 
 def test_unclosed_block_becomes_text(
@@ -310,3 +331,39 @@ def test_lone_opening_brace_is_rejected(parser: TagScriptParser):
     assert nodes == [
         Node.text(text_value=input_str),
     ]
+
+
+def test_unhandled_special_char_in_declaration(
+    parser: TagScriptParser,
+    mock_special_tokens: None,
+):
+    # don't look at it
+    input_str = "{hi~}"
+    with pytest.raises(ValueError) as exc:
+        parser.parse(input_str)
+
+    assert exc.value.args[0] == "Unknown special char '~' in IN_DECLARATION"
+
+
+def test_unhandled_special_char_in_parameter(
+    parser: TagScriptParser,
+    mock_special_tokens_no_colon: None,
+):
+    # don't look at it
+    input_str = "{hello(wo~ah)}"
+    with pytest.raises(ValueError) as exc:
+        parser.parse(input_str)
+
+    assert exc.value.args[0] == "Unknown special char '~' in IN_PARAMETER"
+
+
+def test_unhandled_special_char_in_payload(
+    parser: TagScriptParser,
+    mock_special_tokens_no_colon: None,
+):
+    # don't look at it
+    input_str = "{hello(world):crazy~}"
+    with pytest.raises(ValueError) as exc:
+        parser.parse(input_str)
+
+    assert exc.value.args[0] == "Unknown special char '~' in IN_PAYLOAD"


### PR DESCRIPTION
These work the same as the 0-level fast path by running the index forward until a special character is hit and then assigning the in-between text as the relevant attribute (declaration, parameter, payload).

This resulted in some eye-opening improvements to the parser's performance:

- ~28% faster runtime (9.91s -> 7.14s)
- ~48% less `tottime` for `parse()` (5.73s -> 2.95s)
- ~41% less `cumtime` for `parse()` (6.71s -> 3.95s)

It also had some knock-on effects on block processing due to blocks needing to process recursive segments:
- ~11% faster `cumtime` for `interpreter._process_node` and `interpreter._process_context` (5.96s -> 5.32s and 5.74s -> 5.09s, respectively)
- ~13% speedup for the `process()` method of `AssignBlock` and `IfBlock`
- ~28% speedup for the `process()` method of `JoinBlock` and `ReplaceBlock`

(these results are limited to blocks used in the TagScript used in the `bench.py` script, but similar gains are to be expected from any blocks that call `Context.interpret_segment()`, proportionally to the number of times it is called)

> [!NOTE]
> You may notice that the baseline results are slower than previous benchmarks. This is largely due to the calls to `warnings.warn` for the `_accepted_names` deprecation from PR #40. When run against the removal in #42, both baseline and the changes perform a bit better (you can see the `warn` and `_accepted_names` overhead in the profile output below).

## Current `v1` (d0564804dc7a6cccde2859ddefb2e5ba0c7b3a25)
```console
> python .local\bench.py
         10972072 function calls (9867072 primitive calls) in 9.913 seconds

   Ordered by: cumulative time
   List reduced from 83 to 20 due to restriction	<20>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.005    0.005    9.990    9.990	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.010    0.000    9.985    0.010	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
169000/2000		0.309    0.000    9.975    0.005	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
   156000		5.739    0.000    6.716    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:43(parse)
437000/211000	0.343    0.000    5.966    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.332    0.000    5.744    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.131    0.000    4.970    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.084    0.000    4.774    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:37(process)
53000/49000		0.077    0.000    2.503    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:85(process)
55000/53000		0.083    0.000    1.435    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:17(parse_condition)
   176000		0.187    0.000    0.746    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:119(will_accept)
4000/3000		0.003    0.000    0.725    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:36(process)
10000/1000		0.018    0.000    0.598    0.001	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:46(process)
   352012		0.155    0.000    0.538    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:69(_accepted_names)
   291000		0.134    0.000    0.363    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   352012		0.352    0.000    0.352    0.000	{built-in method _warnings.warn}
   447000		0.158    0.000    0.314    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:252(_flush_text_buffer)
108000/106000	0.083    0.000    0.271    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:68(process)
     5000		0.012    0.000    0.259    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:454(process)
   291000		0.188    0.000    0.228    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
```

## Changes from this PR
```console
> python .local\bench.py
         10972072 function calls (9867072 primitive calls) in 7.149 seconds

   Ordered by: cumulative time
   List reduced from 83 to 20 due to restriction	<20>

   ncalls		tottime  percall  cumtime  percall	filename:lineno(function)
        1		0.004    0.004    7.228    7.228	ya_tagscript\.local\bench.py:190(run_workload)
     1000		0.009    0.000    7.223    0.007	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:61(process)
169000/2000		0.312    0.000    7.213    0.004	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:93(_interpret)
437000/211000	0.342    0.000    5.320    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:149(_process_node)
291000/105000	0.332    0.000    5.097    0.000	ya_tagscript\src\ya_tagscript\interpreter\interpreter.py:129(_process_context)
670000/179000	0.131    0.000    4.325    0.000	ya_tagscript\src\ya_tagscript\interpreter\context.py:28(interpret_segment)
    80000		0.084    0.000    4.147    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\assign_block.py:37(process)
   156000		2.954    0.000    3.952    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:45(parse)
53000/49000		0.078    0.000    2.323    0.000	ya_tagscript\src\ya_tagscript\blocks\conditional\if_block.py:85(process)
55000/53000		0.082    0.000    1.362    0.000	ya_tagscript\src\ya_tagscript\util\conditionals.py:17(parse_condition)
   176000		0.188    0.000    0.747    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:119(will_accept)
   352012		0.155    0.000    0.537    0.000	ya_tagscript\src\ya_tagscript\interfaces\blockabc.py:69(_accepted_names)
4000/3000		0.003    0.000    0.518    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\join_block.py:36(process)
10000/1000		0.018    0.000    0.428    0.000	ya_tagscript\src\ya_tagscript\blocks\strings\replace_block.py:46(process)
   291000		0.137    0.000    0.378    0.000	ya_tagscript\src\ya_tagscript\interpreter\parse_state.py:39(finalize)
   352012		0.351    0.000    0.351    0.000	{built-in method _warnings.warn}
   447000		0.158    0.000    0.320    0.000	ya_tagscript\src\ya_tagscript\interpreter\ts_parser.py:281(_flush_text_buffer)
108000/106000	0.084    0.000    0.273    0.000	ya_tagscript\src\ya_tagscript\blocks\variables\strict_variable_getter_block.py:68(process)
     5000		0.012    0.000    0.247    0.000	ya_tagscript\src\ya_tagscript\blocks\discord\embed_block.py:454(process)
   291000		0.201    0.000    0.241    0.000	ya_tagscript\src\ya_tagscript\interpreter\node.py:53(block)
```