### PR TITLE
Fix escapement breaking if in the middle of 0-level text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - More parsing loop performance improvements
+- Fix escapement bug causing 0-level escaped blocks to not be properly escaped
+    - This change may cause output differences in scripts with escaped blocks.
 
 # v1.7.1 (2026-07-03)
 

--- a/src/ya_tagscript/interpreter/ts_parser.py
+++ b/src/ya_tagscript/interpreter/ts_parser.py
@@ -71,6 +71,7 @@ class TagScriptParser:
                     i += 1
                 text = input_str[start:i]
                 self._text_buffer += text
+                char = input_str[i - 1]
                 continue
 
             # mainly a typing crutch since current_state = block.state (top of loop)

--- a/tests/ya_tagscript/interpreter/test_ts_parser.py
+++ b/tests/ya_tagscript/interpreter/test_ts_parser.py
@@ -367,3 +367,21 @@ def test_unhandled_special_char_in_payload(
         parser.parse(input_str)
 
     assert exc.value.args[0] == "Unknown special char '~' in IN_PAYLOAD"
+
+
+def test_backslash_escapes_block_after_text(parser: TagScriptParser):
+    input_str = r"hello\{world}"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.text(text_value=input_str),
+    ]
+
+
+def test_two_backslashes_escaping_block_in_text_are_not_collapsed(
+    parser: TagScriptParser,
+):
+    input_str = r"hello\\{there}"
+    nodes = parser.parse(input_str)
+    assert nodes == [
+        Node.text(text_value=input_str),
+    ]


### PR DESCRIPTION
Currently, supposedly-escaped blocks are not properly escaped if they sit in the middle of some 0-level text.

This is due to the current `char` of the parsing loop not being updated after the base fast path loop, which in turn leads to previous_char` and the `is_escaped` condition being performed based on the first character of the fast path, as opposed to the last.

This small change fixes that, with some regression tests included.

> [!IMPORTANT]
> This may affect script output with escaped blocks if these blocks are anywhere in the middle of 0-level text.